### PR TITLE
feat: use new lists in maltoolbox attack graph for better performance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ description = "A MAL compliant simulator."
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-  "mal-toolbox==1.*",
+  "mal-toolbox>=1.1.0,<2.0.0",
   "PyYAML>=6.0.1",
   "numpy>=1.21.4",
   "scipy",


### PR DESCRIPTION
- Go through only the type requested (defense/attack step) depending on context
- Insted of going through all nodes every time