### PR TITLE
Document node properties in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ To implement the MAL logic, a few additional properties have been added to nodes
 
 ### Viability
 
-We want to determine which attack steps are possible to compromise in the attack graph with respect to the state of `defense`/`exist`/`notExist` steps. We call that property viability. To get the viability of an attack step, we look at its parents viability.
+We want to determine which attack steps are possible to compromise in the attack graph with respect to the state of `defense`/`exist`/`notExist` steps. We call that property viability. To get the viability of an attack step, we look at its parents' viability.
 Some attack steps have `defense`/`exist`/`notExist` steps as parents. The viability of those steps is determined by whether they are enabled/have their conditions met or not.
 In this way the viability propagates from `defense`/`exist`/`notExist` steps to attack steps and indicates whether the attack steps are viable based on current `defense`/`exists`/`notExist` statuses.
 


### PR DESCRIPTION
- [x] Add viability info to README
- [x] Add necessity info to README
- [x] Add traversability info to README
- [x] Add observability/actionability info (or rename if they match with some other property)
- [x] Add compromised info to README

We want to document these. node properties This will make it easier to understand the logic but also to find opportunities to simplify the logic or rename the properties.

The ideal case would be to minimize the need of these additional properties, or at least make it less complex, or at least be transparent on how it works.

Once we have settled the definitions, we should also add this to the MAL wiki.