### PR TITLE
Remove settings to enable/disable false positives/negatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,6 @@ settings = MalSimulatorSettings(
     run_defense_step_bernoullis: bool = True
     attacker_reward_mode: RewardMode = RewardMode.CUMULATIVE
     defender_reward_mode: RewardMode = RewardMode.CUMULATIVE
-    enable_false_positives: bool = False
-    enable_false_negatives: bool = False
 )
 sim = MalSimulator(attack_graph, sim_settings=settings, ...)
 

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -709,10 +709,11 @@ def test_simulator_false_positives() -> None:
         'tests/testdata/scenarios/traininglang_fp_fn_scenario.yml'
     )
 
+    scenario.false_negative_rates = {}
+
     sim = MalSimulator.from_scenario(
         scenario, sim_settings=MalSimulatorSettings(
-            enable_false_positives=True,
-            seed=100
+            seed=30
         ), max_iter=100
     )
     run_simulation(sim, scenario.agents)
@@ -733,9 +734,10 @@ def test_simulator_false_negatives() -> None:
         'tests/testdata/scenarios/traininglang_fp_fn_scenario.yml'
     )
 
+    scenario.false_positive_rates = {}
+
     sim = MalSimulator.from_scenario(
         scenario, sim_settings=MalSimulatorSettings(
-            enable_false_negatives=True,
             seed=100
         ), max_iter=100
     )


### PR DESCRIPTION
- Instead assume rates are 0 if they are not set in the scenario, which results in the same thing