### PR TITLE
feat: false positives / negatives also on reset

### DIFF
--- a/malsim/mal_simulator.py
+++ b/malsim/mal_simulator.py
@@ -765,14 +765,18 @@ class MalSimulator():
             compromised_steps |= attacker_state.performed_nodes
 
         defense_surface = self._get_defense_surface()
+        step_observed_nodes = (
+            self._defender_observed_nodes(compromised_steps)
+        )
+
         defender_state = MalSimDefenderState(
             name,
             sim = self,
             performed_nodes = frozenset(self._enabled_defenses),
             compromised_nodes = frozenset(compromised_steps),
             step_compromised_nodes = frozenset(compromised_steps),
-            observed_nodes = frozenset(compromised_steps),
-            step_observed_nodes = frozenset(compromised_steps),
+            observed_nodes = frozenset(step_observed_nodes),
+            step_observed_nodes = frozenset(step_observed_nodes),
             action_surface = frozenset(defense_surface),
             step_action_surface_additions = frozenset(defense_surface),
             step_action_surface_removals = frozenset(),

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -926,6 +926,25 @@ def test_simulator_false_positives() -> None:
     assert len(defender_state.observed_nodes) > len(defender_state.compromised_nodes)
 
 
+def test_simulator_false_positives_reset() -> None:
+    """Create a simulator with false positives"""
+
+    scenario = load_scenario(
+        'tests/testdata/scenarios/traininglang_fp_fn_scenario.yml'
+    )
+
+    scenario.false_negative_rates = {}
+    sim = MalSimulator.from_scenario(
+        scenario, sim_settings=MalSimulatorSettings(
+            seed=7
+        ), max_iter=100
+    )
+    defender_state = sim.reset()['defender']
+    assert isinstance(defender_state, MalSimDefenderState)
+    # Should be false positive in defender state even on reset
+    assert len(defender_state.observed_nodes) > len(defender_state.compromised_nodes)
+
+
 def test_simulator_false_negatives() -> None:
     """Create a simulator with false negatives"""
 


### PR DESCRIPTION
Possibly partial/false observability for defender also in reset.