### PR TITLE
feat: Use actionability to limit agent action surfaces

### DIFF
--- a/malsim/mal_simulator.py
+++ b/malsim/mal_simulator.py
@@ -628,9 +628,7 @@ class MalSimulator:
                     and not self.node_is_necessary(child)
                 ):
                     continue
-                if (
-                    not self.node_is_actionable(child)
-                ):
+                if not self.node_is_actionable(child):
                     continue
                 if child not in attack_surface and self.node_is_traversable(
                     performed_nodes, child

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -128,19 +128,19 @@ def test_register_agent_action_surface(
 
 def test_simulator_actionable_action_surface(model: Model) -> None:
     scenario = Scenario(
-        lang_file = 'tests/testdata/langs/org.mal-lang.coreLang-1.0.0.mar',
+        lang_file='tests/testdata/langs/org.mal-lang.coreLang-1.0.0.mar',
         model=model,
-        is_actionable={'by_asset_type': {
-            'Application': ['attemptRead', 'successfulRead', 'read', 'notPresent']}
+        is_actionable={
+            'by_asset_type': {
+                'Application': ['attemptRead', 'successfulRead', 'read', 'notPresent']
+            }
         },
         agents={
             'Attacker1': {
                 'type': 'attacker',
                 'entry_points': ['OS App:fullAccess'],
             },
-            'Defender': {
-                'type': 'defender'
-            }
+            'Defender': {'type': 'defender'},
         },
     )
     sim = MalSimulator.from_scenario(scenario)
@@ -152,7 +152,8 @@ def test_simulator_actionable_action_surface(model: Model) -> None:
 
     # Only Application:notPresent defenses in defenders action surface
     assert states['Defender'].action_surface == {
-        sim.get_node('OS App:notPresent'), sim.get_node('Program 2:notPresent')
+        sim.get_node('OS App:notPresent'),
+        sim.get_node('Program 2:notPresent'),
     }
 
 


### PR DESCRIPTION
This was previously just implemented in Jakobs interface, but it makes sense that the result of being actionable/non actionable is to be or not to be in the action surface of any agent.

Note:
The annoying thing with actionability is that you would have to make every single type of node actionable except for one if you want to make one node non-actionable.

Actionability is also not set by agent type, so you would need to add actionability for both defense and attack steps even though you are just working from defender or attacker perspective and want the other type of agent to have full actionability.

This makes actionability kind of shitty. Any ideas?