### PR TITLE
Remove max iter and put iterations in the state

### DIFF
--- a/malsim/envs/graph/utils.py
+++ b/malsim/envs/graph/utils.py
@@ -168,7 +168,7 @@ def create_full_obs(sim: MalSimulator, serializer: LangSerializer) -> MALObsInst
         asset2asset_links = np.empty((2, 0), dtype=np.int64)
 
     return MALObsInstance(
-        time=np.int64(sim.cur_iter),
+        time=np.int64(1),
         assets=assets,
         steps=steps,
         associations=association,

--- a/malsim/mal_simulator/agent_state.py
+++ b/malsim/mal_simulator/agent_state.py
@@ -170,7 +170,7 @@ def create_attacker_state(
         ttc_overrides=MappingProxyType(ttc_overrides),
         ttc_value_overrides=MappingProxyType(ttc_value_overrides),
         impossible_step_overrides=frozenset(impossible_step_overrides),
-        iteration=(previous_state.iteration + 1) if previous_state else 0,
+        iteration=(previous_state.iteration + 1) if previous_state else 1,
     )
 
 
@@ -240,5 +240,5 @@ def create_defender_state(
         action_surface=frozenset(action_surface),
         step_performed_nodes=frozenset(step_enabled_defenses),
         step_unviable_nodes=frozenset(step_nodes_made_unviable),
-        iteration=(previous_state.iteration + 1) if previous_state else 0,
+        iteration=(previous_state.iteration + 1) if previous_state else 1,
     )

--- a/scripts/profile_simulation.py
+++ b/scripts/profile_simulation.py
@@ -31,13 +31,10 @@ def main():
         default='simulation_profile.prof',
         help='File to save profiling results',
     )
-    parser.add_argument(
-        '--max_iter', type=int, default=100, help='MAX iterations in simulator'
-    )
 
     args = parser.parse_args()
     scenario = Scenario.load_from_file(args.scenario_file)
-    sim = MalSimulator.from_scenario(scenario, max_iter=args.max_iter)
+    sim = MalSimulator.from_scenario(scenario)
 
     # Run the profiler
     profiler = cProfile.Profile()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,7 @@ def path_testdata(filename: str) -> str:
 def fixture_env() -> MalSimVectorizedObsEnv:
     attack_graph = create_attack_graph(lang_file_name, model_file_name)
     attack_graph.save_to_file(attack_graph_file_name)
-    env = MalSimVectorizedObsEnv(MalSimulator(attack_graph, max_iter=1000))
+    env = MalSimVectorizedObsEnv(MalSimulator(attack_graph))
     env.register_defender('defender')
 
     os_app_fa = get_node(attack_graph, 'OS App:fullAccess')

--- a/tests/envs/test_example_scenarios.py
+++ b/tests/envs/test_example_scenarios.py
@@ -83,8 +83,8 @@ def test_bfs_vs_bfs_state_and_reward() -> None:
         total_reward_defender += sim.agent_reward(defender_state.name)
         total_reward_attacker += sim.agent_reward(attacker_state.name)
 
-    assert defender_state.iteration == 44
-    assert attacker_state.iteration == 44
+    assert defender_state.iteration == 45
+    assert attacker_state.iteration == 45
 
     # Make sure the actions performed were as expected
     assert attacker_actions == [
@@ -375,8 +375,8 @@ def test_bfs_vs_bfs_state_and_reward_per_step_effort_based() -> None:
         total_reward_defender += sim.agent_reward(defender_state.name)
         total_reward_attacker += sim.agent_reward(attacker_state.name)
 
-    assert attacker_state.iteration == 11
-    assert defender_state.iteration == 11
+    assert attacker_state.iteration == 12
+    assert defender_state.iteration == 12
 
     # Make sure the actions performed were as expected
     assert attacker_actions == [
@@ -486,8 +486,8 @@ def test_bfs_vs_bfs_state_and_reward_expected_value_ttc() -> None:
         total_reward_defender += sim.agent_reward(defender_state.name)
         total_reward_attacker += sim.agent_reward(attacker_state.name)
 
-    assert attacker_state.iteration == 11
-    assert defender_state.iteration == 11
+    assert attacker_state.iteration == 12
+    assert defender_state.iteration == 12
 
     # Make sure the actions performed were as expected
     assert attacker_actions == [

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -460,7 +460,7 @@ def test_get_node(corelang_lang_graph: LanguageGraph, model: Model) -> None:
 def test_simulation_done(corelang_lang_graph: LanguageGraph, model: Model) -> None:
     attack_graph = AttackGraph(corelang_lang_graph, model)
     entry_point = get_node(attack_graph, 'OS App:fullAccess')
-    sim = MalSimulator(attack_graph, max_iter=9)
+    sim = MalSimulator(attack_graph)
 
     defender_name = 'Test defender'
     sim.register_defender(defender_name)
@@ -478,7 +478,7 @@ def test_simulation_done(corelang_lang_graph: LanguageGraph, model: Model) -> No
     defender_state = states[defender_name]
     assert isinstance(defender_state, MalSimDefenderState)
 
-    assert sim.done()  # simulation is done because truncated
+    assert not sim.done()  # simulation is done because truncated
     assert not sim._defender_is_terminated()  # not terminated
     assert not sim._attacker_is_terminated(attacker_state)  # not terminated
 
@@ -921,7 +921,7 @@ def test_simulator_false_positives() -> None:
     scenario.false_negative_rates = None
 
     sim = MalSimulator.from_scenario(
-        scenario, sim_settings=MalSimulatorSettings(seed=30), max_iter=100
+        scenario, sim_settings=MalSimulatorSettings(seed=30)
     )
     run_simulation(sim, scenario.agent_settings)
 
@@ -944,7 +944,7 @@ def test_simulator_false_positives_reset() -> None:
     scenario.false_negative_rates = None
 
     sim = MalSimulator.from_scenario(
-        scenario, sim_settings=MalSimulatorSettings(seed=9), max_iter=100
+        scenario, sim_settings=MalSimulatorSettings(seed=9)
     )
     defender_state = sim.reset()['defender']
     assert isinstance(defender_state, MalSimDefenderState)
@@ -961,7 +961,7 @@ def test_simulator_false_negatives() -> None:
     scenario.false_positive_rates = None
 
     sim = MalSimulator.from_scenario(
-        scenario, sim_settings=MalSimulatorSettings(seed=100), max_iter=100
+        scenario, sim_settings=MalSimulatorSettings(seed=100)
     )
     run_simulation(sim, scenario.agent_settings)
 
@@ -982,7 +982,7 @@ def test_simulator_no_fpr_fnr() -> None:
     )
 
     sim = MalSimulator.from_scenario(
-        scenario, sim_settings=MalSimulatorSettings(seed=100), max_iter=100
+        scenario, sim_settings=MalSimulatorSettings(seed=100)
     )
     run_simulation(sim, scenario.agent_settings)
 
@@ -1061,7 +1061,6 @@ def test_simulator_multiple_attackers() -> None:
     sim = MalSimulator.from_scenario(
         scenario,
         sim_settings=MalSimulatorSettings(seed=100),
-        max_iter=100,
         register_agents=False,
     )
 
@@ -1121,7 +1120,6 @@ def test_simulator_multiple_defenders() -> None:
     sim = MalSimulator.from_scenario(
         scenario,
         sim_settings=MalSimulatorSettings(seed=100),
-        max_iter=100,
         register_agents=False,
     )
 
@@ -1173,7 +1171,6 @@ def test_simulator_attacker_override_ttcs_state() -> None:
     sim = MalSimulator.from_scenario(
         scenario,
         sim_settings=MalSimulatorSettings(seed=100, ttc_mode=TTCMode.PRE_SAMPLE),
-        max_iter=100,
     )
     states = sim.reset()
 
@@ -1328,7 +1325,6 @@ def test_simulator_picklable() -> None:
 
     assert type(restored) is type(sim)
     assert restored.sim_settings == sim.sim_settings
-    assert restored.max_iter == sim.max_iter
 
     # Compare attack graph dicts
     assert restored.attack_graph._to_dict() == sim.attack_graph._to_dict()


### PR DESCRIPTION
This PR does two things.

- Remove max iters. I think the use of this parameter has been misinterpreted, so it is safer to not have the simulator handle it.
- Move the current iteration into the state. The current iteration is stateful, so it should be maintained in the state. If it makes more sense that time is shared in the simulator, there should be an underlying sim state class.