### PR TITLE
Break up Simulator class

### DIFF
--- a/malsim/envs/graph/graph_env.py
+++ b/malsim/envs/graph/graph_env.py
@@ -222,7 +222,7 @@ class MalSimGraph(ParallelEnv[str, MALObsInstance, np.int64]):
         }
         self._full_obs = create_full_obs(self.sim, self.lang_serializer)
         self.possible_agents = [name for name in self.sim.agent_states.keys()]
-        self.agents = list(self.sim._alive_agents)
+        self.agents = list(self.sim.alive_agents)
 
     def reset(
         self, seed: int | None = None, options: dict[str, Any] | None = None
@@ -274,7 +274,7 @@ class MalSimGraph(ParallelEnv[str, MALObsInstance, np.int64]):
             for agent_name, action_idx in actions.items()
         }
         states = self.sim.step(action_nodes)
-        self.agents = list(self.sim._alive_agents)
+        self.agents = list(self.sim.alive_agents)
         self._obs = {
             agent_name: (
                 full_obs2attacker_obs(

--- a/malsim/envs/legacy/malsim_vectorized_obs_env.py
+++ b/malsim/envs/legacy/malsim_vectorized_obs_env.py
@@ -93,12 +93,12 @@ class MalSimVectorizedObsEnv(ParallelEnv):
     @property
     def agents(self) -> list[str]:
         """Required by ParallelEnv"""
-        return list(self.sim._alive_agents)
+        return list(self.sim.alive_agents)
 
     @property
     def possible_agents(self) -> list[str]:
         """Required by ParallelEnv"""
-        return list(self.sim._agent_states.keys())
+        return list(self.sim.agent_states.keys())
 
     def get_agent_state(self, agent_name: str) -> MalSimAgentState:
         return self.sim.agent_states[agent_name]

--- a/tests/agents/test_agents.py
+++ b/tests/agents/test_agents.py
@@ -66,8 +66,8 @@ def test_defend_compromised_defender(dummy_lang_graph: LanguageGraph) -> None:
     defender_ai = DefendCompromisedDefender(agent_config)
 
     # Should pick cheapest one
-    sim._rewards[node1] = 100
-    sim._rewards[node2] = 10
+    sim.rewards[node1] = 100
+    sim.rewards[node2] = 10
 
     # Get next action
     assert isinstance(agent_state, MalSimDefenderState)
@@ -76,8 +76,8 @@ def test_defend_compromised_defender(dummy_lang_graph: LanguageGraph) -> None:
     assert action_node.id == node2.id
 
     # Should pick cheapest one
-    sim._rewards[node1] = 10
-    sim._rewards[node2] = 100
+    sim.rewards[node1] = 10
+    sim.rewards[node2] = 100
 
     # Get next action
     action_node = defender_ai.get_next_action(agent_state)

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -42,12 +42,12 @@ def test_reset(corelang_lang_graph: LanguageGraph, model: Model) -> None:
     sim = MalSimulator(attack_graph, sim_settings=MalSimulatorSettings(seed=10))
 
     viability_before = {
-        n.full_name: v for n, v in sim._graph_state.viability_per_node.items()
+        n.full_name: v for n, v in sim.graph_state.viability_per_node.items()
     }
     necessity_before = {
-        n.full_name: v for n, v in sim._graph_state.necessity_per_node.items()
+        n.full_name: v for n, v in sim.graph_state.necessity_per_node.items()
     }
-    enabled_defenses = {n.full_name for n in sim._graph_state.pre_enabled_defenses}
+    enabled_defenses = {n.full_name for n in sim.graph_state.pre_enabled_defenses}
     sim.register_attacker_settings(AttackerSettings(attacker_name, {agent_entry_point}))
     assert attacker_name in sim.agent_states
     assert len(sim.agent_states) == 1
@@ -59,7 +59,7 @@ def test_reset(corelang_lang_graph: LanguageGraph, model: Model) -> None:
     attacker_state = sim.agent_states[attacker_name]
     assert action_surface_before == {n.full_name for n in attacker_state.action_surface}
     assert enabled_defenses == {
-        n.full_name for n in sim._graph_state.pre_enabled_defenses
+        n.full_name for n in sim.graph_state.pre_enabled_defenses
     }
 
     sim.reset()
@@ -77,11 +77,11 @@ def test_reset(corelang_lang_graph: LanguageGraph, model: Model) -> None:
     # Re-creating the simulator object with the same seed
     # should result in getting the same viability and necessity values
     sim = MalSimulator(attack_graph, sim_settings=MalSimulatorSettings(seed=10))
-    for node, viable in sim._graph_state.viability_per_node.items():
+    for node, viable in sim.graph_state.viability_per_node.items():
         # viability is the same after reset
         assert viability_before[node.full_name] == viable
 
-    for node, necessary in sim._graph_state.necessity_per_node.items():
+    for node, necessary in sim.graph_state.necessity_per_node.items():
         # necessity is the same after reset
         assert necessity_before[node.full_name] == necessary
 
@@ -128,7 +128,7 @@ def test_register_agent_action_surface(
     defender_state = sim.agent_states[agent_name]
     action_surface = defender_state.action_surface
     for node in action_surface:
-        assert node not in sim._graph_state.pre_enabled_defenses
+        assert node not in sim.graph_state.pre_enabled_defenses
 
 
 def test_simulator_actionable_action_surface(model: Model) -> None:
@@ -202,7 +202,7 @@ def test_attacker_step(corelang_lang_graph: LanguageGraph, model: Model) -> None
     sim.register_attacker(attacker_name, {entry_point})
     sim.reset()
 
-    attacker_agent = sim._agent_states[attacker_name]
+    attacker_agent = sim.agent_states[attacker_name]
     assert isinstance(attacker_agent, MalSimAttackerState)
 
     # Can not attack the notPresent step
@@ -223,7 +223,7 @@ def test_defender_step(corelang_lang_graph: LanguageGraph, model: Model) -> None
     sim.register_defender(defender_name)
     sim.reset()
 
-    defender_agent = sim._agent_states[defender_name]
+    defender_agent = sim.agent_states[defender_name]
     assert isinstance(defender_agent, MalSimDefenderState)
 
     defense_step = get_node(attack_graph, 'OS App:notPresent')
@@ -688,7 +688,7 @@ def test_agent_state_views_simple(
     state_views = sim.agent_states
     entry_point = get_node(attack_graph, 'OS App:fullAccess')
 
-    pre_enabled_defenses = set(sim._graph_state.pre_enabled_defenses)
+    pre_enabled_defenses = set(sim.graph_state.pre_enabled_defenses)
 
     asv = state_views['attacker']
     dsv = state_views['defender']
@@ -1039,13 +1039,13 @@ def test_simulator_ttcs() -> None:
     #     network_3_access: 1.0
     # }
 
-    assert not sim._graph_state.impossible_attack_steps
-    assert not sim._graph_state.pre_enabled_defenses
+    assert not sim.graph_state.impossible_attack_steps
+    assert not sim.graph_state.pre_enabled_defenses
 
     sim.reset()
 
-    assert not sim._graph_state.impossible_attack_steps
-    assert not sim._graph_state.pre_enabled_defenses
+    assert not sim.graph_state.impossible_attack_steps
+    assert not sim.graph_state.pre_enabled_defenses
 
 
 def test_simulator_multiple_attackers() -> None:
@@ -1174,7 +1174,7 @@ def test_simulator_attacker_override_ttcs_state() -> None:
     )
     states = sim.reset()
 
-    bad_attacker_settings = sim._agent_settings['BadAttacker']
+    bad_attacker_settings = sim.agent_settings['BadAttacker']
     assert isinstance(bad_attacker_settings, AttackerSettings)
     assert bad_attacker_settings.ttc_overrides is not None
     bad_attacker_state = states['BadAttacker']
@@ -1398,6 +1398,6 @@ def test_active_defenses() -> None:
         ),
     )
 
-    assert len(sim._graph_state.pre_enabled_defenses) == 2
-    assert sim.get_node('Creds:notGuessable') in sim._graph_state.pre_enabled_defenses
-    assert sim.get_node('Creds:notDisclosed') in sim._graph_state.pre_enabled_defenses
+    assert len(sim.graph_state.pre_enabled_defenses) == 2
+    assert sim.get_node('Creds:notGuessable') in sim.graph_state.pre_enabled_defenses
+    assert sim.get_node('Creds:notDisclosed') in sim.graph_state.pre_enabled_defenses


### PR DESCRIPTION
This is a step towards breaking up the simulator class by moving all the functions from it outside the class, while preserving the same functionality externally. It is a bit of a stop-gap change which makes the result look a bit silly.

Steps that should follow:

1. Exchange `sim` parameter to relevant values
2. Move functions into separate files.

These steps can be separate PR:s, however, to not make the change too large.