### PR TITLE
Correct acronym expansion in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The **MAL Simulator** is a tool designed for running simulations on systems modeled in the **Modeling Attack Language (MAL)**.
+The **MAL Simulator** is a tool designed for running simulations on systems modeled in the **Meta Attack Language (MAL)**.
 
 It allows you to:
 * Simulate the adversarial and defensive actions of intelligent agents (attackers and defenders).


### PR DESCRIPTION
Updated the acronym expansion from 'Modeling Attack Language' to 'Meta Attack Language'.