### PR TITLE
Make searchers not rely on step_*

### DIFF
--- a/malsim/policies/attackers/searchers.py
+++ b/malsim/policies/attackers/searchers.py
@@ -161,7 +161,7 @@ def _update_targets(
     ],
     disabled_nodes: frozenset[AttackGraphNode],
     current_target: Optional[AttackGraphNode] = None,
-):
+) -> deque[AttackGraphNode]:
     if current_target and current_target not in disabled_nodes:
         # If self.current_target was not compromised, e.g. due to TTCs,
         # it remains in action surface and should be added as a target.

--- a/malsim/policies/attackers/searchers.py
+++ b/malsim/policies/attackers/searchers.py
@@ -19,7 +19,12 @@ logger = logging.getLogger(__name__)
 class ActionOrdering(Enum):
     RANDOM = 'random'  # randomize the order of new targets at each step
     SORTED = 'sorted'  # sort by node id
-    NOTHING = 'nothing'  # rely on the ordering of the action surface set, which is theoeritically non-deterministic and may lead to non-deterministic simulations
+    # rely on the built-in ordering of the action surface set,
+    # which is theoeritically non-deterministic
+    # but in practice deterministic in CPython due to the way sets are implemented.
+    NOTHING = 'nothing'
+    # shuffle but without sorting first, which may lead to non-deterministic simulations
+    LIST_RANDOM = 'list_random'
 
 
 @dataclass
@@ -47,9 +52,22 @@ def parse_agent_config(config_dict: dict[str, Any]) -> AgentConfig:
     return AgentConfig(action_ordering=action_ordering, seed=seed)
 
 
-def shuffle(rng: random.Random, nodes: list[AttackGraphNode]) -> list[AttackGraphNode]:
+def sort_and_shuffle(
+    rng: random.Random, nodes: frozenset[AttackGraphNode]
+) -> list[AttackGraphNode]:
     """Shuffle a list of nodes using the provided random generator."""
-    nodes_copy = nodes.copy()
+    # sort to ensure deterministic order before shuffling
+    nodes_copy = sorted(nodes, key=lambda n: n.id)
+    rng.shuffle(nodes_copy)
+    return nodes_copy
+
+
+def shuffle(
+    rng: random.Random, nodes: frozenset[AttackGraphNode]
+) -> list[AttackGraphNode]:
+    """Shuffle a list of nodes using the provided random generator."""
+    # sort to ensure deterministic order before shuffling
+    nodes_copy = list(nodes)
     rng.shuffle(nodes_copy)
     return nodes_copy
 
@@ -64,7 +82,6 @@ class BreadthFirstAttacker(DecisionAgent):
         action_ordering=ActionOrdering.NOTHING,
         seed=None,
     )
-    _extend_method = 'extendleft'
 
     def __init__(self, agent_config: AgentConfig | dict[str, Any]) -> None:
         """Initialize a BFS/DFS agent.
@@ -83,27 +100,28 @@ class BreadthFirstAttacker(DecisionAgent):
 
         settings = replace(self._default_settings, **config.__dict__)
 
-        self._rng = random.Random(config.seed)
         self._prev_state = None
 
-        # _rng = random.Random(config.seed)
-        # order_funcs: dict[
-        #     ActionOrdering,
-        #     Callable[[frozenset[AttackGraphNode]], list[AttackGraphNode]],
-        # ] = {
-        #     ActionOrdering.RANDOM: lambda nodes: list(shuffle(_rng, list(nodes))),
-        #     ActionOrdering.SORTED: lambda nodes: sorted(nodes, key=lambda n: n.id),
-        #     ActionOrdering.NOTHING: lambda nodes: list(nodes),
-        # }
-        # self.order_func = order_funcs[config.action_ordering]
+        _rng = random.Random(config.seed)
+        order_funcs: dict[
+            ActionOrdering,
+            Callable[[frozenset[AttackGraphNode]], list[AttackGraphNode]],
+        ] = {
+            ActionOrdering.RANDOM: lambda nodes: list(sort_and_shuffle(_rng, nodes)),
+            ActionOrdering.SORTED: lambda nodes: sorted(nodes, key=lambda n: n.id),
+            ActionOrdering.NOTHING: lambda nodes: list(nodes),
+            ActionOrdering.LIST_RANDOM: lambda nodes: list(shuffle(_rng, nodes)),
+        }
+        self.order_func = order_funcs[config.action_ordering]
         self._settings = settings
 
-    # def extend_method(
-    #     self, targets: deque[AttackGraphNode], new_nodes: list[AttackGraphNode]
-    # ) -> deque[AttackGraphNode]:
-    #     """Extend the deque of targets with new nodes according to the policy of the agent (BFS or DFS)"""
-    #     targets.extendleft(new_nodes)
-    #     return targets
+    def extend_method(
+        self, targets: deque[AttackGraphNode], new_nodes: list[AttackGraphNode]
+    ) -> deque[AttackGraphNode]:
+        """Extend the deque of targets with new nodes
+        according to the policy of the agent (BFS or DFS)"""
+        targets.extendleft(new_nodes)
+        return targets
 
     def get_next_action(
         self, agent_state: MalSimAgentState, **kwargs: Any
@@ -116,16 +134,16 @@ class BreadthFirstAttacker(DecisionAgent):
             else agent_state.action_surface
         )
 
-        disabled_nodes = (
+        disabled_nodes: frozenset[AttackGraphNode] = (
             self._prev_state.action_surface - agent_state.action_surface
             if self._prev_state
             else frozenset()
         )
 
-        self._targets = self._update_targets(
-            new_nodes=new_nodes,
+        self._targets = _update_targets(
+            new_targets=self.order_func(new_nodes),
             old_target_queue=self._targets,
-            extend_method=self._extend_method,
+            extend_method=self.extend_method,
             disabled_nodes=disabled_nodes,
             current_target=self._current_target,
         )
@@ -134,44 +152,31 @@ class BreadthFirstAttacker(DecisionAgent):
         self._prev_state = agent_state
         return self._current_target
 
-    def _update_targets(
-        self,
-        new_nodes: list[AttackGraphNode],
-        old_target_queue: deque[AttackGraphNode],
-        extend_method: str,
-        disabled_nodes: frozenset[AttackGraphNode],
-        current_target: Optional[AttackGraphNode] = None,
-    ):
-        new_targets: list[AttackGraphNode] = []
-        if self._settings.action_ordering == ActionOrdering.SORTED:
-            # If a seed is set, we assume the user wants determinism in the
-            # simulation. Thus, we sort to an ordered list to make sure the
-            # non-deterministic ordering of the action_surface set does not
-            # break simulation determinism.
-            new_targets = sorted(new_nodes, key=lambda n: n.id)
-        else:
-            # sorted above returns a list already
-            new_targets = list(new_nodes)
 
-        if self._settings.action_ordering == ActionOrdering.RANDOM:
-            new_targets = sorted(new_nodes, key=lambda n: n.id)
-            self._rng.shuffle(new_targets)
+def _update_targets(
+    new_targets: list[AttackGraphNode],
+    old_target_queue: deque[AttackGraphNode],
+    extend_method: Callable[
+        [deque[AttackGraphNode], list[AttackGraphNode]], deque[AttackGraphNode]
+    ],
+    disabled_nodes: frozenset[AttackGraphNode],
+    current_target: Optional[AttackGraphNode] = None,
+):
+    if current_target and current_target not in disabled_nodes:
+        # If self.current_target was not compromised, e.g. due to TTCs,
+        # it remains in action surface and should be added as a target.
+        old_target_queue.append(current_target)
 
-        if current_target and current_target not in disabled_nodes:
-            # If self.current_target was not compromised, e.g. due to TTCs,
-            # it remains in action surface and should be added as a target.
-            old_target_queue.append(current_target)
+    # Enabled defenses may remove previously possible attack steps.
+    new_target_queue = (
+        deque(n for n in old_target_queue if n not in disabled_nodes)
+        if disabled_nodes
+        else old_target_queue
+    )
 
-        # Enabled defenses may remove previously possible attack steps.
-        new_target_queue = (
-            deque(n for n in old_target_queue if n not in disabled_nodes)
-            if disabled_nodes
-            else old_target_queue
-        )
+    # Use the extend method to add new targets
+    return extend_method(new_target_queue, new_targets)
 
-        # Use the extend method to add new targets
-        getattr(new_target_queue, extend_method)(new_targets)
-        return new_target_queue
 
 def _select_next_target(
     targets: deque[AttackGraphNode] | None,
@@ -187,10 +192,9 @@ def _select_next_target(
 
 class DepthFirstAttacker(BreadthFirstAttacker):
     name = 'Depth First Attacker'
-    _extend_method = 'extend'  # DFS extends to the right, BFS extends to the left
 
-    # def extend_method(
-    #     self, targets: deque[AttackGraphNode], new_nodes: list[AttackGraphNode]
-    # ) -> deque[AttackGraphNode]:
-    #     targets.extend(new_nodes)
-    #     return targets
+    def extend_method(
+        self, targets: deque[AttackGraphNode], new_nodes: list[AttackGraphNode]
+    ) -> deque[AttackGraphNode]:
+        targets.extend(new_nodes)
+        return targets

--- a/malsim/policies/attackers/searchers.py
+++ b/malsim/policies/attackers/searchers.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from collections.abc import Set, Callable
 from dataclasses import dataclass, replace
 from enum import Enum
 import logging

--- a/malsim/policies/attackers/searchers.py
+++ b/malsim/policies/attackers/searchers.py
@@ -45,30 +45,36 @@ class BreadthFirstAttacker(DecisionAgent):
         self._settings = self._default_settings | agent_config
 
         self._rng = random.Random(self._settings.get('seed'))
-        self._started = False
+        self.prev_state = None
 
     def get_next_action(
         self, agent_state: MalSimAgentState, **kwargs: Any
     ) -> Optional[AttackGraphNode]:
         """Receive the next action according to agent policy (bfs/dfs)"""
 
+        new_nodes = (
+            agent_state.action_surface - self.prev_state.action_surface
+            if self.prev_state
+            else agent_state.action_surface
+        )
+
+        disabled_nodes = (
+            self.prev_state.action_surface - agent_state.action_surface
+            if self.prev_state
+            else set()
+        )
+
         self._targets = self._update_targets(
-            new_nodes=set(
-                agent_state.step_action_surface_additions
-                if self._started
-                else agent_state.action_surface
-            ),
+            new_nodes=new_nodes,
             old_target_queue=self._targets,
-            disabled_nodes=set(
-                agent_state.step_action_surface_removals
-                | agent_state.step_performed_nodes
-            ),
+            disabled_nodes=disabled_nodes,
             current_target=self._current_target,
             extend_method=self._extend_method,
         )
 
         self._current_target = self._select_next_target()
         self._started = True
+        self.prev_state = agent_state
         return self._current_target
 
     def _update_targets(

--- a/malsim/policies/attackers/searchers.py
+++ b/malsim/policies/attackers/searchers.py
@@ -63,6 +63,8 @@ class BreadthFirstAttacker(DecisionAgent):
                 agent_state.step_action_surface_removals
                 | agent_state.step_performed_nodes
             ),
+            current_target=self._current_target,
+            extend_method=self._extend_method,
         )
 
         self._current_target = self._select_next_target()
@@ -74,6 +76,8 @@ class BreadthFirstAttacker(DecisionAgent):
         new_nodes: set[AttackGraphNode],
         old_target_queue: deque[AttackGraphNode],
         disabled_nodes: set[AttackGraphNode],
+        extend_method: str,
+        current_target: Optional[AttackGraphNode] = None,
     ) -> deque[AttackGraphNode]:
         new_targets: list[AttackGraphNode] = []
         if self._settings['seed']:
@@ -89,21 +93,20 @@ class BreadthFirstAttacker(DecisionAgent):
         if self._settings['randomize']:
             self._rng.shuffle(new_targets)
 
-        if self._current_target and self._current_target not in disabled_nodes:
+        if current_target and current_target not in disabled_nodes:
             # If self.current_target was not compromised, e.g. due to TTCs,
             # it remains in action surface and should be added as a target.
-            old_target_queue.append(self._current_target)
+            old_target_queue.append(current_target)
 
         # Enabled defenses may remove previously possible attack steps.
-        if disabled_nodes:
-            new_target_queue = deque(
-                n for n in old_target_queue if n not in disabled_nodes
-            )
-        else:
-            new_target_queue = old_target_queue
+        new_target_queue = (
+            deque(n for n in old_target_queue if n not in disabled_nodes)
+            if disabled_nodes
+            else old_target_queue
+        )
 
         # Use the extend method to add new targets
-        getattr(new_target_queue, self._extend_method)(new_targets)
+        getattr(new_target_queue, extend_method)(new_targets)
         return new_target_queue
 
     def _select_next_target(self) -> AttackGraphNode | None:

--- a/malsim/policies/attackers/searchers.py
+++ b/malsim/policies/attackers/searchers.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from collections.abc import Callable, Set
 from dataclasses import dataclass, replace
 from enum import Enum
 import logging
@@ -53,7 +54,7 @@ def parse_agent_config(config_dict: dict[str, Any]) -> AgentConfig:
 
 
 def sort_and_shuffle(
-    rng: random.Random, nodes: frozenset[AttackGraphNode]
+    rng: random.Random, nodes: Set[AttackGraphNode]
 ) -> list[AttackGraphNode]:
     """Shuffle a list of nodes using the provided random generator."""
     # sort to ensure deterministic order before shuffling
@@ -62,9 +63,7 @@ def sort_and_shuffle(
     return nodes_copy
 
 
-def shuffle(
-    rng: random.Random, nodes: frozenset[AttackGraphNode]
-) -> list[AttackGraphNode]:
+def shuffle(rng: random.Random, nodes: Set[AttackGraphNode]) -> list[AttackGraphNode]:
     """Shuffle a list of nodes using the provided random generator."""
     # sort to ensure deterministic order before shuffling
     nodes_copy = list(nodes)
@@ -105,7 +104,7 @@ class BreadthFirstAttacker(DecisionAgent):
         _rng = random.Random(config.seed)
         order_funcs: dict[
             ActionOrdering,
-            Callable[[frozenset[AttackGraphNode]], list[AttackGraphNode]],
+            Callable[[Set[AttackGraphNode]], list[AttackGraphNode]],
         ] = {
             ActionOrdering.RANDOM: lambda nodes: list(sort_and_shuffle(_rng, nodes)),
             ActionOrdering.SORTED: lambda nodes: sorted(nodes, key=lambda n: n.id),
@@ -134,7 +133,7 @@ class BreadthFirstAttacker(DecisionAgent):
             else agent_state.action_surface
         )
 
-        disabled_nodes: frozenset[AttackGraphNode] = (
+        disabled_nodes: Set[AttackGraphNode] = (
             self._prev_state.action_surface - agent_state.action_surface
             if self._prev_state
             else frozenset()
@@ -159,7 +158,7 @@ def _update_targets(
     extend_method: Callable[
         [deque[AttackGraphNode], list[AttackGraphNode]], deque[AttackGraphNode]
     ],
-    disabled_nodes: frozenset[AttackGraphNode],
+    disabled_nodes: Set[AttackGraphNode],
     current_target: Optional[AttackGraphNode] = None,
 ) -> deque[AttackGraphNode]:
     if current_target and current_target not in disabled_nodes:

--- a/malsim/policies/attackers/searchers.py
+++ b/malsim/policies/attackers/searchers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
-from collections.abc import Set
+from collections.abc import Set, Callable
+from dataclasses import dataclass, replace
+from enum import Enum
 import logging
 import random
 
@@ -15,26 +17,57 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class ActionOrdering(Enum):
+    RANDOM = 'random'  # randomize the order of new targets at each step
+    SORTED = 'sorted'  # sort by node id
+    NOTHING = 'nothing'  # rely on the ordering of the action surface set, which is theoeritically non-deterministic and may lead to non-deterministic simulations
+
+
+@dataclass
+class AgentConfig:
+    # Whether to sort next target selection, still respecting the
+    # policy of the agent (BFS or DFS).
+    action_ordering: ActionOrdering = ActionOrdering.NOTHING
+    # The random seed to initialize the randomness engine with.
+    # If None, no seed is set and thus results may be non-deterministic.
+    seed: Optional[int] = None
+
+
+def parse_agent_config(config_dict: dict[str, Any]) -> AgentConfig:
+    """Parse a dict into an AgentConfig, validating the fields."""
+    try:
+        action_ordering = ActionOrdering(config_dict.get('action_ordering', 'nothing'))
+    except ValueError as e:
+        raise ValueError(
+            f'Invalid action_ordering: {config_dict.get("action_ordering")}. '
+            f'Valid options are: {[ao.value for ao in ActionOrdering]}'
+        ) from e
+    seed = config_dict.get('seed')
+    if seed is not None and not isinstance(seed, int):
+        raise ValueError(f'Seed must be an integer or None, got {type(seed)}')
+    return AgentConfig(action_ordering=action_ordering, seed=seed)
+
+
+def shuffle(rng: random.Random, nodes: list[AttackGraphNode]) -> list[AttackGraphNode]:
+    """Shuffle a list of nodes using the provided random generator."""
+    nodes_copy = nodes.copy()
+    rng.shuffle(nodes_copy)
+    return nodes_copy
+
+
 class BreadthFirstAttacker(DecisionAgent):
     """A Breadth-First agent, with possible randomization at each level."""
 
     # A human-friendly name for the agent.
     name = 'Breadth First Attacker'
 
-    # Controls where newly discovered steps will be appended to the deque of
-    # available actions. Differentiates between BFS and DFS agents.
+    _default_settings: ClassVar[AgentConfig] = AgentConfig(
+        action_ordering=ActionOrdering.NOTHING,
+        seed=None,
+    )
     _extend_method = 'extendleft'
 
-    _default_settings: ClassVar[dict[str, Any]] = {
-        # Whether to randomize next target selection, still respecting the
-        # policy of the agent (BFS or DFS).
-        'randomize': False,
-        # The random seed to initialize the randomness engine with.
-        # If set, the simulation will be deterministic.
-        'seed': None,
-    }
-
-    def __init__(self, agent_config: dict[str, Any]) -> None:
+    def __init__(self, agent_config: AgentConfig | dict[str, Any]) -> None:
         """Initialize a BFS/DFS agent.
 
         Args:
@@ -42,10 +75,36 @@ class BreadthFirstAttacker(DecisionAgent):
         """
         self._targets: deque[AttackGraphNode] = deque()
         self._current_target: Optional[AttackGraphNode] = None
-        self._settings = self._default_settings | agent_config
 
-        self._rng = random.Random(self._settings.get('seed'))
-        self.prev_state = None
+        config = (
+            parse_agent_config(agent_config)
+            if isinstance(agent_config, dict)
+            else agent_config
+        )
+
+        settings = replace(self._default_settings, **config.__dict__)
+
+        self._rng = random.Random(config.seed)
+        self._prev_state = None
+
+        # _rng = random.Random(config.seed)
+        # order_funcs: dict[
+        #     ActionOrdering,
+        #     Callable[[frozenset[AttackGraphNode]], list[AttackGraphNode]],
+        # ] = {
+        #     ActionOrdering.RANDOM: lambda nodes: list(shuffle(_rng, list(nodes))),
+        #     ActionOrdering.SORTED: lambda nodes: sorted(nodes, key=lambda n: n.id),
+        #     ActionOrdering.NOTHING: lambda nodes: list(nodes),
+        # }
+        # self.order_func = order_funcs[config.action_ordering]
+        self._settings = settings
+
+    # def extend_method(
+    #     self, targets: deque[AttackGraphNode], new_nodes: list[AttackGraphNode]
+    # ) -> deque[AttackGraphNode]:
+    #     """Extend the deque of targets with new nodes according to the policy of the agent (BFS or DFS)"""
+    #     targets.extendleft(new_nodes)
+    #     return targets
 
     def get_next_action(
         self, agent_state: MalSimAgentState, **kwargs: Any
@@ -53,40 +112,39 @@ class BreadthFirstAttacker(DecisionAgent):
         """Receive the next action according to agent policy (bfs/dfs)"""
 
         new_nodes = (
-            agent_state.action_surface - self.prev_state.action_surface
-            if self.prev_state
+            agent_state.action_surface - self._prev_state.action_surface
+            if self._prev_state
             else agent_state.action_surface
         )
 
         disabled_nodes = (
-            self.prev_state.action_surface - agent_state.action_surface
-            if self.prev_state
-            else set()
+            self._prev_state.action_surface - agent_state.action_surface
+            if self._prev_state
+            else frozenset()
         )
 
         self._targets = self._update_targets(
             new_nodes=new_nodes,
             old_target_queue=self._targets,
+            extend_method=self._extend_method,
             disabled_nodes=disabled_nodes,
             current_target=self._current_target,
-            extend_method=self._extend_method,
         )
 
-        self._current_target = self._select_next_target()
-        self._started = True
-        self.prev_state = agent_state
+        self._current_target = _select_next_target(self._targets)
+        self._prev_state = agent_state
         return self._current_target
 
     def _update_targets(
         self,
-        new_nodes: set[AttackGraphNode],
+        new_nodes: list[AttackGraphNode],
         old_target_queue: deque[AttackGraphNode],
-        disabled_nodes: set[AttackGraphNode],
         extend_method: str,
+        disabled_nodes: frozenset[AttackGraphNode],
         current_target: Optional[AttackGraphNode] = None,
-    ) -> deque[AttackGraphNode]:
+    ):
         new_targets: list[AttackGraphNode] = []
-        if self._settings['seed']:
+        if self._settings.action_ordering == ActionOrdering.SORTED:
             # If a seed is set, we assume the user wants determinism in the
             # simulation. Thus, we sort to an ordered list to make sure the
             # non-deterministic ordering of the action_surface set does not
@@ -96,7 +154,8 @@ class BreadthFirstAttacker(DecisionAgent):
             # sorted above returns a list already
             new_targets = list(new_nodes)
 
-        if self._settings['randomize']:
+        if self._settings.action_ordering == ActionOrdering.RANDOM:
+            new_targets = sorted(new_nodes, key=lambda n: n.id)
             self._rng.shuffle(new_targets)
 
         if current_target and current_target not in disabled_nodes:
@@ -115,16 +174,24 @@ class BreadthFirstAttacker(DecisionAgent):
         getattr(new_target_queue, extend_method)(new_targets)
         return new_target_queue
 
-    def _select_next_target(self) -> AttackGraphNode | None:
-        """
-        Implement the actual next target selection logic.
-        """
-        if self._targets:
-            return self._targets.pop()
-        else:
-            return None
+def _select_next_target(
+    targets: deque[AttackGraphNode] | None,
+) -> AttackGraphNode | None:
+    """
+    Implement the actual next target selection logic.
+    """
+    if targets:
+        return targets.pop()
+    else:
+        return None
 
 
 class DepthFirstAttacker(BreadthFirstAttacker):
     name = 'Depth First Attacker'
-    _extend_method = 'extend'
+    _extend_method = 'extend'  # DFS extends to the right, BFS extends to the left
+
+    # def extend_method(
+    #     self, targets: deque[AttackGraphNode], new_nodes: list[AttackGraphNode]
+    # ) -> deque[AttackGraphNode]:
+    #     targets.extend(new_nodes)
+    #     return targets

--- a/malsim/policies/attackers/searchers.py
+++ b/malsim/policies/attackers/searchers.py
@@ -100,7 +100,7 @@ class BreadthFirstAttacker(DecisionAgent):
 
         settings = replace(self._default_settings, **config.__dict__)
 
-        self._prev_state = None
+        self._prev_state: MalSimAgentState | None = None
 
         _rng = random.Random(config.seed)
         order_funcs: dict[

--- a/malsim/policies/attackers/searchers.py
+++ b/malsim/policies/attackers/searchers.py
@@ -64,7 +64,7 @@ class BreadthFirstAttacker(DecisionAgent):
             ),
         )
 
-        self._select_next_target()
+        self._current_target = self._select_next_target()
         self._started = True
         return self._current_target
 
@@ -99,14 +99,14 @@ class BreadthFirstAttacker(DecisionAgent):
         # Use the extend method to add new targets
         getattr(self._targets, self._extend_method)(new_targets)
 
-    def _select_next_target(self) -> None:
+    def _select_next_target(self) -> AttackGraphNode | None:
         """
         Implement the actual next target selection logic.
         """
         if self._targets:
-            self._current_target = self._targets.pop()
+            return self._targets.pop()
         else:
-            self._current_target = None
+            return None
 
 
 class DepthFirstAttacker(BreadthFirstAttacker):

--- a/malsim/policies/attackers/searchers.py
+++ b/malsim/policies/attackers/searchers.py
@@ -52,12 +52,13 @@ class BreadthFirstAttacker(DecisionAgent):
     ) -> Optional[AttackGraphNode]:
         """Receive the next action according to agent policy (bfs/dfs)"""
 
-        self._update_targets(
+        self._targets = self._update_targets(
             new_nodes=set(
                 agent_state.step_action_surface_additions
                 if self._started
                 else agent_state.action_surface
             ),
+            old_target_queue=self._targets,
             disabled_nodes=set(
                 agent_state.step_action_surface_removals
                 | agent_state.step_performed_nodes
@@ -70,9 +71,10 @@ class BreadthFirstAttacker(DecisionAgent):
 
     def _update_targets(
         self,
-        new_nodes: Set[AttackGraphNode],
-        disabled_nodes: Set[AttackGraphNode],
-    ) -> None:
+        new_nodes: set[AttackGraphNode],
+        old_target_queue: deque[AttackGraphNode],
+        disabled_nodes: set[AttackGraphNode],
+    ) -> deque[AttackGraphNode]:
         new_targets: list[AttackGraphNode] = []
         if self._settings['seed']:
             # If a seed is set, we assume the user wants determinism in the
@@ -90,14 +92,19 @@ class BreadthFirstAttacker(DecisionAgent):
         if self._current_target and self._current_target not in disabled_nodes:
             # If self.current_target was not compromised, e.g. due to TTCs,
             # it remains in action surface and should be added as a target.
-            self._targets.append(self._current_target)
+            old_target_queue.append(self._current_target)
 
         # Enabled defenses may remove previously possible attack steps.
         if disabled_nodes:
-            self._targets = deque(n for n in self._targets if n not in disabled_nodes)
+            new_target_queue = deque(
+                n for n in old_target_queue if n not in disabled_nodes
+            )
+        else:
+            new_target_queue = old_target_queue
 
         # Use the extend method to add new targets
-        getattr(self._targets, self._extend_method)(new_targets)
+        getattr(new_target_queue, self._extend_method)(new_targets)
+        return new_target_queue
 
     def _select_next_target(self) -> AttackGraphNode | None:
         """

--- a/tests/testdata/scenarios/bfs_vs_bfs_network_app_data_scenario.yml
+++ b/tests/testdata/scenarios/bfs_vs_bfs_network_app_data_scenario.yml
@@ -14,7 +14,7 @@ agents:
     agent_class: BreadthFirstAttacker
     type: attacker
     config:
-      seed: 1
+      action_ordering: sorted
     entry_points:
       - 'Internet:accessUninspected'
 
@@ -22,4 +22,4 @@ agents:
     agent_class: BreadthFirstAttacker
     type: defender
     config:
-      seed: 1
+      action_ordering: sorted

--- a/tests/testdata/scenarios/bfs_vs_bfs_scenario.yml
+++ b/tests/testdata/scenarios/bfs_vs_bfs_scenario.yml
@@ -17,7 +17,7 @@ agents:
     type: attacker
     config:
       seed: 1
-      randomize: True
+      action_ordering: random
     entry_points:
       - 'Program 1:fullAccess'
 
@@ -26,4 +26,4 @@ agents:
     type: defender
     config:
       seed: 1
-      randomize: True
+      action_ordering: random


### PR DESCRIPTION
I am thinking of removing the step_* fields of the state classes in favor of storing a step_* for the state object itself. This is a change is primarily to remove the reliance of step_* from the searchers.

I also made a bunch of other changes to make the searcher classes less of an OOP mess.

