### PR TITLE
make extend recurse into mappings

### DIFF
--- a/malsim/scenario/scenario.py
+++ b/malsim/scenario/scenario.py
@@ -243,14 +243,15 @@ def recursive_update(
     old: Mapping[str, Any], new: Mapping[str, Any]
 ) -> Mapping[str, Any]:
     """Recursively update dict d with dict u"""
+    combined_keys = set(old.keys()) | set(new.keys())
+
     return {
         k: recursive_update(old.get(k, {}), new.get(k, {}))
-        if isinstance(v, Mapping)
-        and isinstance(old.get(k), Mapping)
-        and isinstance(new.get(k), Mapping)
+        if isinstance(old.get(k), Mapping) and isinstance(new.get(k), Mapping)
         else new.get(k, old.get(k))
-        for k, v in old.items()
-        if new.get(k) is not None or old.get(k) is not None
+        for k in combined_keys
+        # check for explicit None to allow overriding values to None
+        if not (k in new and new[k] is None)
     }
 
 

--- a/malsim/scenario/scenario.py
+++ b/malsim/scenario/scenario.py
@@ -172,7 +172,7 @@ class Scenario:
 
     @classmethod
     def load_from_file(cls, scenario_file: str, **override_keys: Any) -> Scenario:
-        scenario_dict = load_scenario_dict(scenario_file)
+        scenario_dict = dict(load_scenario_dict(scenario_file))
         return cls.from_dict(scenario_dict | override_keys)
 
 
@@ -226,26 +226,33 @@ def path_relative_to_file_dir(rel_path: str, file: TextIO) -> str:
 
 
 def _extend_scenario(
-    original_scenario_path: str, overriding_scenario: dict[str, Any]
-) -> dict[str, Any]:
+    original_scenario_path: str, overriding_scenario: Mapping[str, Any]
+) -> Mapping[str, Any]:
     """
     Override settings in `original_scenario_path` with settings
     in `overriding_scenario` and return the result.
     """
 
-    original_scenario: dict[str, Any] = load_scenario_dict(original_scenario_path)
-    resulting_scenario = original_scenario.copy()
-    for key, value in overriding_scenario.items():
-        # Override the original scenario with the
-        # overriding scenario key,value pairs
-        if key == 'extends':
-            # The 'extends' key is not needed after extend is done
-            continue
-        resulting_scenario[key] = value
-    return resulting_scenario
+    original_scenario: Mapping[str, Any] = load_scenario_dict(original_scenario_path)
+    resulting_scenario = recursive_update(original_scenario, overriding_scenario)
+    return dict(filter(lambda item: item[0] != 'extends', resulting_scenario.items()))
 
 
-def load_scenario_dict(scenario_file: str) -> dict[str, Any]:
+def recursive_update(
+    old: Mapping[str, Any], new: Mapping[str, Any]
+) -> Mapping[str, Any]:
+    """Recursively update dict d with dict u"""
+    return {
+        k: recursive_update(old.get(k, {}), new.get(k, {}))
+        if isinstance(v, Mapping)
+        and isinstance(old.get(k), Mapping)
+        and isinstance(new.get(k), Mapping)
+        else new.get(k, old.get(k))
+        for k, v in old.items()
+    }
+
+
+def load_scenario_dict(scenario_file: str) -> Mapping[str, Any]:
     """From a scenario file, load a scenario dict.
 
     Extend it with other scenario if `extend` keyword is used.
@@ -257,7 +264,7 @@ def load_scenario_dict(scenario_file: str) -> dict[str, Any]:
             original_scenario_path = path_relative_to_file_dir(
                 scenario['extends'], s_file
             )
-            scenario = _extend_scenario(original_scenario_path, scenario)
+            scenario = dict(_extend_scenario(original_scenario_path, scenario))
 
         # Convert path relative to scenario file
         scenario['lang_file'] = path_relative_to_file_dir(scenario['lang_file'], s_file)

--- a/malsim/scenario/scenario.py
+++ b/malsim/scenario/scenario.py
@@ -152,6 +152,7 @@ class Scenario:
         agent_settings = [
             agent_settings_from_dict(name, agent_settings_dict)
             for name, agent_settings_dict in scenario_dict['agents'].items()
+            if agent_settings_dict is not None
         ]
 
         model_or_model_file = scenario_dict.get('model') or scenario_dict['model_file']
@@ -249,6 +250,7 @@ def recursive_update(
         and isinstance(new.get(k), Mapping)
         else new.get(k, old.get(k))
         for k, v in old.items()
+        if new.get(k) is not None or old.get(k) is not None
     }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ warn_no_return = true
 disallow_untyped_calls = true
 disallow_untyped_defs = true
 disallow_any_generics = true
-allow_subclassing_any = true
+disallow_subclassing_any = false
 
 [tool.ruff]
 line-length = 88

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -150,8 +150,10 @@ def test_extend_scenario_deeper() -> None:
             assert reward == 1
     assert num_nodes_with_reward == 7
 
-    # 2 agents are defined in the original scenario
-    assert len(scenario.agent_settings) == 2
+    # 2 agents are defined in the original scenario,
+    # but one is set to null in the final scenario,
+    # so only 1 agent should be present in the final scenario
+    assert len(scenario.agent_settings) == 1
 
 
 def test_extend_scenario_override_lang_model() -> None:

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -150,8 +150,8 @@ def test_extend_scenario_deeper() -> None:
             assert reward == 1
     assert num_nodes_with_reward == 7
 
-    # 1 agents are defined in the extended_again scenario
-    assert len(scenario.agent_settings) == 1
+    # 2 agents are defined in the original scenario
+    assert len(scenario.agent_settings) == 2
 
 
 def test_extend_scenario_override_lang_model() -> None:

--- a/tests/testdata/scenarios/sub/traininglang_scenario_extended_again.yml
+++ b/tests/testdata/scenarios/sub/traininglang_scenario_extended_again.yml
@@ -1,6 +1,7 @@
 extends: ../traininglang_scenario_extended.yml
 
 agents:
+  'Attacker1': null
   'Defender1':
     type: 'defender'
     rewards:


### PR DESCRIPTION
Change behavior of extend to recurse into mappings, since the current extend is not super useful otherwise with the new settings revision.

This changes the behavior slightly, however, since before it would override the agents dict completely rather than extend it.