### PR TITLE
remove alive agents field

### DIFF
--- a/malsim/envs/graph/graph_env.py
+++ b/malsim/envs/graph/graph_env.py
@@ -232,7 +232,7 @@ class MalSimGraph(ParallelEnv[str, MALObsInstance, np.int64]):
         }
         self._full_obs = create_full_obs(self.sim, self.lang_serializer)
         self.possible_agents = list(self.sim.agent_states)
-        self.agents = list(self.sim._alive_agents)
+        self.agents = list(self.sim.alive_agents)
 
     def reset(
         self, seed: int | None = None, options: dict[str, Any] | None = None
@@ -284,7 +284,7 @@ class MalSimGraph(ParallelEnv[str, MALObsInstance, np.int64]):
             for agent_name, action_idx in actions.items()
         }
         states = self.sim.step(action_nodes)
-        self.agents = list(self.sim._alive_agents)
+        self.agents = list(self.sim.alive_agents)
         self._obs = {
             agent_name: (
                 full_obs2attacker_obs(

--- a/malsim/envs/graph/utils.py
+++ b/malsim/envs/graph/utils.py
@@ -3,7 +3,7 @@ from collections.abc import MutableSet
 from maltoolbox.language import LanguageGraphAssociation
 import numpy as np
 
-from malsim.mal_simulator.agent_states import get_attacker_agents
+from malsim.mal_simulator.agent_states import attacker_states
 
 from .mal_spaces import (
     Assets,
@@ -25,13 +25,13 @@ def create_full_obs(sim: MalSimulator, serializer: LangSerializer) -> MALObsInst
     def get_total_attempts(node: AttackGraphNode) -> int:
         return sum(
             state.num_attempts.get(node, 0)
-            for state in get_attacker_agents(sim.agent_states, sim._alive_agents)
+            for state in attacker_states(sim.agent_states).values()
         )
 
     def is_traversable_by_any(node: AttackGraphNode) -> bool:
         return any(
             sim.node_is_traversable(state.performed_nodes, node)
-            for state in get_attacker_agents(sim.agent_states, sim._alive_agents)
+            for state in attacker_states(sim.agent_states).values()
         )
 
     # NOTE: Sorting is for defender

--- a/malsim/envs/legacy/malsim_vectorized_obs_env.py
+++ b/malsim/envs/legacy/malsim_vectorized_obs_env.py
@@ -94,7 +94,7 @@ class MalSimVectorizedObsEnv(ParallelEnv[str, dict[str, Any], dict[str, str]]):
     @property
     def agents(self) -> list[str]:
         """Required by ParallelEnv"""
-        return list(self.sim._alive_agents)
+        return list(self.sim.alive_agents)
 
     @property
     def possible_agents(self) -> list[str]:

--- a/malsim/mal_simulator/agent_states.py
+++ b/malsim/mal_simulator/agent_states.py
@@ -1,36 +1,7 @@
 from malsim.mal_simulator.attacker_state import MalSimAttackerState
 from malsim.mal_simulator.defender_state import MalSimDefenderState
-from collections.abc import Set
 
 AgentStates = dict[str, MalSimAttackerState | MalSimDefenderState]
-
-
-def get_attacker_agents(
-    agent_states: AgentStates, alive_agents: Set[str], only_alive: bool = False
-) -> list[MalSimAttackerState]:
-    """Return list of mutable attacker agent states of attackers.
-    If `only_alive` is set to True, only return the agents that are alive.
-    """
-    return [
-        a
-        for a in agent_states.values()
-        if (a.name in alive_agents or not only_alive)
-        and isinstance(a, MalSimAttackerState)
-    ]
-
-
-def get_defender_agents(
-    agent_states: AgentStates, alive_agents: Set[str], only_alive: bool = False
-) -> list[MalSimDefenderState]:
-    """Return list of mutable defender agent states of defenders.
-    If `only_alive` is set to True, only return the agents that are alive.
-    """
-    return [
-        a
-        for a in agent_states.values()
-        if (a.name in alive_agents or not only_alive)
-        and isinstance(a, MalSimDefenderState)
-    ]
 
 
 def defender_states(agent_states: AgentStates) -> dict[str, MalSimDefenderState]:

--- a/malsim/mal_simulator/defender_step.py
+++ b/malsim/mal_simulator/defender_step.py
@@ -5,7 +5,7 @@ from maltoolbox.attackgraph import AttackGraphNode
 import logging
 
 
-from malsim.mal_simulator.agent_states import get_attacker_agents
+from malsim.mal_simulator.agent_states import attacker_states
 from malsim.mal_simulator.attacker_step import attacker_is_terminated
 from malsim.mal_simulator.graph_processing import make_node_unviable
 from malsim.mal_simulator.simulator_state import MalSimulatorState
@@ -17,14 +17,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def defender_is_terminated(agent_states: AgentStates, alive_agents: Set[str]) -> bool:
+def defender_is_terminated(agent_states: AgentStates) -> bool:
     """Check if defender is terminated
     Can be overridden by subclass for custom termination condition.
     """
     # Defender is terminated if all attackers are terminated
     return all(
-        attacker_is_terminated(a)
-        for a in get_attacker_agents(agent_states, alive_agents)
+        attacker_is_terminated(a) for a in attacker_states(agent_states).values()
     )
 
 

--- a/malsim/mal_simulator/reset_agent.py
+++ b/malsim/mal_simulator/reset_agent.py
@@ -1,11 +1,14 @@
-from collections.abc import MutableSet, Set
+from collections.abc import Mapping, Set
+
 
 import numpy as np
 
 from maltoolbox.attackgraph import AttackGraphNode
 
 from malsim.config.sim_settings import MalSimulatorSettings
+from .attacker_state import MalSimAttackerState
 from malsim.mal_simulator.attacker_state_factories import initial_attacker_state
+from .defender_state import MalSimDefenderState
 from malsim.mal_simulator.defender_state_factories import initial_defender_state
 from malsim.mal_simulator.simulator_state import MalSimulatorState
 from malsim.config.agent_settings import (
@@ -21,26 +24,18 @@ def reset_attackers(
     sim_settings: MalSimulatorSettings,
     agent_settings: AgentSettings,
     rng: np.random.Generator,
-) -> tuple[AgentStates, Set[str], Set[AttackGraphNode]]:
+) -> Mapping[str, MalSimAttackerState]:
     """Recreate all attacker agent states"""
 
-    attacker_states: AgentStates = {}
-    alive_attackers: MutableSet[str] = set()
-    pre_compromised_nodes: Set[AttackGraphNode] = set()
-
-    for attacker_settings in get_attacker_settings(agent_settings).values():
-        # Get any overriding ttc settings from attacker settings
-        new_attacker_state = initial_attacker_state(
+    return {
+        name: initial_attacker_state(
             sim_state,
             sim_settings=sim_settings,
             attacker_settings=attacker_settings,
             rng=rng,
         )
-        pre_compromised_nodes |= new_attacker_state.step_performed_nodes
-        alive_attackers.add(attacker_settings.name)
-        attacker_states[attacker_settings.name] = new_attacker_state
-
-    return attacker_states, alive_attackers, pre_compromised_nodes
+        for name, attacker_settings in get_attacker_settings(agent_settings).items()
+    }
 
 
 def reset_defenders(
@@ -48,23 +43,18 @@ def reset_defenders(
     agent_settings: AgentSettings,
     pre_compromised_nodes: Set[AttackGraphNode],
     rng: np.random.Generator,
-) -> tuple[AgentStates, Set[str]]:
+) -> Mapping[str, MalSimDefenderState]:
     """Recreate all defender agent states"""
-    defender_states: AgentStates = {}
-    alive_defenders: MutableSet[str] = set()
-
-    for defender_settings in get_defender_settings(agent_settings).values():
-        new_defender_state = initial_defender_state(
+    return {
+        name: initial_defender_state(
             sim_state,
             defender_settings,
             pre_compromised_nodes,
             sim_state.graph_state.pre_enabled_defenses,
             rng,
         )
-        alive_defenders.add(defender_settings.name)
-        defender_states[defender_settings.name] = new_defender_state
-
-    return defender_states, frozenset(alive_defenders)
+        for name, defender_settings in get_defender_settings(agent_settings).items()
+    }
 
 
 def reset_agents(
@@ -72,18 +62,19 @@ def reset_agents(
     sim_settings: MalSimulatorSettings,
     agent_settings: AgentSettings,
     rng: np.random.Generator,
-) -> tuple[AgentStates, Set[str]]:
+) -> AgentStates:
     """Reset agent states to a fresh start"""
 
-    attacker_states, alive_attackers, pre_compromised_nodes = reset_attackers(
-        sim_state, sim_settings, agent_settings, rng
-    )
+    attacker_states = reset_attackers(sim_state, sim_settings, agent_settings, rng)
 
-    defender_states, alive_defenders = reset_defenders(
+    pre_compromised_nodes: Set[AttackGraphNode] = {
+        node
+        for state in attacker_states.values()
+        for node in state.step_performed_nodes
+    }
+
+    defender_states = reset_defenders(
         sim_state, agent_settings, pre_compromised_nodes, rng
     )
 
-    return (
-        attacker_states | defender_states,
-        alive_attackers | alive_defenders,
-    )
+    return {**attacker_states, **defender_states}

--- a/malsim/mal_simulator/simulator.py
+++ b/malsim/mal_simulator/simulator.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 import logging
 from typing import Any, NamedTuple, Optional
-from collections.abc import Callable, Iterable, Mapping, MutableSet, Set
-from copy import copy
+from collections.abc import Callable, Iterable, Mapping, Set
 import numpy as np
 from numpy.random import default_rng
 
@@ -14,8 +13,8 @@ from malsim.config.agent_settings import defender_settings
 from malsim.config.agent_settings import attacker_settings
 from malsim.mal_simulator.agent_states import (
     AgentStates,
-    get_attacker_agents,
-    get_defender_agents,
+    attacker_states,
+    defender_states,
 )
 from malsim.mal_simulator.attacker_state import MalSimAttackerState
 from malsim.mal_simulator.attacker_step import (
@@ -161,7 +160,7 @@ class MalSimulator:
             a.name: a for a in (_defender_settings + attacker_settings_with_nodes)
         } or {}
 
-        agent_states, alive_agents, sim_state, recording = reset(
+        agent_states, sim_state, recording = reset(
             static_sim_data,
             _agent_settings,
             rng,
@@ -189,7 +188,6 @@ class MalSimulator:
         # Set all instance variables
         self.rng = rng
         self._agent_states = agent_states
-        self._alive_agents = alive_agents
         self.sim_state = sim_state
         self.recording = recording
         self.sim_settings = sim_settings
@@ -223,7 +221,11 @@ class MalSimulator:
         return create_simulator_from_scenario(scenario, send_to_api)
 
     def done(self) -> bool:
-        return done(self._alive_agents)
+        return done(self.alive_agents)
+
+    @property
+    def alive_agents(self) -> Set[str]:
+        return alive_agents(self._agent_states)
 
     def node_ttc_value(
         self, node: AttackGraphNode, agent_name: Optional[str] = None
@@ -290,7 +292,6 @@ class MalSimulator:
         return node_is_enabled_defense(
             self.sim_state.attack_graph,
             self._agent_states,
-            self._alive_agents,
             node,
         )
 
@@ -298,7 +299,6 @@ class MalSimulator:
         return node_is_compromised(
             self.sim_state.attack_graph,
             self._agent_states,
-            self._alive_agents,
             node,
         )
 
@@ -306,7 +306,6 @@ class MalSimulator:
     def compromised_nodes(self) -> Set[AttackGraphNode]:
         return compromised_nodes(
             self._agent_states,
-            self._alive_agents,
         )
 
     def node_is_traversable(
@@ -328,12 +327,11 @@ class MalSimulator:
         return self._agent_reward_from_state(agent_state) or 0.0
 
     def agent_is_terminated(self, agent_name: str) -> bool:
-        return agent_is_terminated(self._agent_states, self._alive_agents, agent_name)
+        return agent_is_terminated(self._agent_states, agent_name)
 
     def reset(self) -> dict[str, MalSimAttackerState | MalSimDefenderState]:
         (
             self._agent_states,
-            self._alive_agents,
             self.sim_state,
             self.recording,
         ) = reset(
@@ -350,7 +348,7 @@ class MalSimulator:
         return self._agent_states
 
     def _defender_is_terminated(self) -> bool:
-        return defender_is_terminated(self._agent_states, self._alive_agents)
+        return defender_is_terminated(self._agent_states)
 
     def _agent_reward_from_state(
         self, state: MalSimAttackerState | MalSimDefenderState
@@ -372,11 +370,10 @@ class MalSimulator:
     def step(
         self, actions: dict[str, list[AttackGraphNode]] | dict[str, list[str]]
     ) -> dict[str, MalSimAttackerState | MalSimDefenderState]:
-        agent_states, recording, sim_state, live_agents = step(
+        agent_states, recording, sim_state = step(
             self.recording,
             self.sim_state,
             self._agent_states,
-            set(self._alive_agents),
             self.rng,
             actions,
             self.rest_api_client,
@@ -384,7 +381,6 @@ class MalSimulator:
         self._agent_states = agent_states
         self.recording = recording
         self.sim_state = sim_state
-        self._alive_agents = live_agents
 
         return self._agent_states
 
@@ -410,15 +406,13 @@ def done(alive_agents: Set[str]) -> bool:
     return len(alive_agents) == 0
 
 
-def agent_is_terminated(
-    agent_states: AgentStates, live_agents: Set[str], agent_name: str
-) -> bool:
+def agent_is_terminated(agent_states: AgentStates, agent_name: str) -> bool:
     """Return True if agent was terminated"""
     agent_state = agent_states[agent_name]
     if isinstance(agent_state, MalSimAttackerState):
         return attacker_is_terminated(agent_state)
     elif isinstance(agent_state, MalSimDefenderState):
-        return defender_is_terminated(agent_states, live_agents)
+        return defender_is_terminated(agent_states)
     else:
         raise TypeError(f'Unknown agent state for {agent_name}')
 
@@ -430,7 +424,6 @@ def reset(
     rest_api_client: Optional[MalSimGUIClient],
 ) -> tuple[
     AgentStates,
-    Set[str],
     MalSimulatorState,
     Recording,
 ]:
@@ -443,7 +436,7 @@ def reset(
     graph_state = compute_initial_graph_state(attack_graph, settings, rng)
     sim_state = create_simulator_state(attack_graph, graph_state, settings)
 
-    agent_states, alive_agents = reset_agents(
+    agent_states = reset_agents(
         sim_state,
         settings,
         agent_settings,
@@ -453,7 +446,7 @@ def reset(
     if rest_api_client:
         rest_api_client.upload_initial_state(attack_graph)
 
-    return agent_states, alive_agents, sim_state, defaultdict(dict)
+    return agent_states, sim_state, defaultdict(dict)
 
 
 def _pre_step_check(
@@ -479,11 +472,10 @@ def step(
     recording: Recording,
     sim_state: MalSimulatorState,
     agent_states: AgentStates,
-    alive_agents: MutableSet[str],
     rng: np.random.Generator,
     actions: dict[str, list[AttackGraphNode]] | dict[str, list[str]],
     rest_api_client: Optional[MalSimGUIClient] = None,
-) -> tuple[AgentStates, Recording, MalSimulatorState, Set[str]]:
+) -> tuple[AgentStates, Recording, MalSimulatorState]:
     """Take a step in the simulation
 
     Args:
@@ -494,7 +486,7 @@ def step(
     - A dictionary containing the agent state views keyed by agent names
     """
 
-    _pre_step_check(agent_states, alive_agents, actions)
+    _pre_step_check(agent_states, alive_agents(agent_states), actions)
 
     # Populate these from the results for all agents' actions.
     step_compromised_nodes: list[AttackGraphNode] = []
@@ -503,7 +495,7 @@ def step(
     current_iteration = 0
 
     # Perform defender actions first
-    for defender_state in get_defender_agents(agent_states, alive_agents):
+    for defender_state in defender_states(agent_states).values():
         agent_actions = list(
             full_names_or_nodes_to_nodes(
                 sim_state.attack_graph, actions.get(defender_state.name, [])
@@ -517,7 +509,7 @@ def step(
         step_nodes_made_unviable |= unviable
 
     # Perform attacker actions afterwards
-    for attacker_state in get_attacker_agents(agent_states, alive_agents):
+    for attacker_state in attacker_states(agent_states).values():
         agent_actions = list(
             full_names_or_nodes_to_nodes(
                 sim_state.attack_graph, actions.get(attacker_state.name, [])
@@ -545,7 +537,7 @@ def step(
         )
 
     # Update defender states and rewards
-    for defender_state in get_defender_agents(agent_states, alive_agents):
+    for defender_state in defender_states(agent_states).values():
         current_iteration = defender_state.iteration
         # Update defender state
         agent_states[defender_state.name] = create_defender_state(
@@ -559,13 +551,6 @@ def step(
             rng=rng,
         )
 
-    # Mark terminated agents as dead
-    for agent_name in copy(alive_agents):
-        # Remove agents that are terminated
-        if agent_is_terminated(agent_states, alive_agents, agent_name):
-            logger.info('Agent %s terminated', agent_name)
-            alive_agents.remove(agent_name)
-
     # the way current_iteration is used here is flawed.
     if rest_api_client:
         rest_api_client.upload_performed_nodes(
@@ -573,4 +558,13 @@ def step(
             current_iteration,
         )
 
-    return agent_states, recording, sim_state, alive_agents
+    return agent_states, recording, sim_state
+
+
+def alive_agents(agent_states: AgentStates) -> Set[str]:
+    """Return a set of alive agents"""
+    return {
+        agent_name
+        for agent_name in agent_states
+        if not agent_is_terminated(agent_states, agent_name)
+    }

--- a/malsim/mal_simulator/state_query.py
+++ b/malsim/mal_simulator/state_query.py
@@ -7,46 +7,43 @@ from maltoolbox.attackgraph import AttackGraphNode
 from maltoolbox.attackgraph import AttackGraph
 
 from malsim.mal_simulator.attacker_state import MalSimAttackerState
-from malsim.mal_simulator.agent_states import get_defender_agents
+from malsim.mal_simulator.agent_states import defender_states
 from malsim.mal_simulator.node_getters import full_name_or_node_to_node
 from malsim.config.sim_settings import TTCMode
-from malsim.mal_simulator.agent_states import AgentStates, get_attacker_agents
+from malsim.mal_simulator.agent_states import AgentStates, attacker_states
 
 
 def node_is_enabled_defense(
     attack_graph: AttackGraph,
     agent_states: AgentStates,
-    live_agents: Set[str],
     node: AttackGraphNode | str,
 ) -> bool:
     """Get a nodes defense status"""
     node = full_name_or_node_to_node(attack_graph, node)
     return any(
         node in attacker_agent.performed_nodes
-        for attacker_agent in get_defender_agents(agent_states, live_agents)
+        for attacker_agent in defender_states(agent_states).values()
     )
 
 
 def node_is_compromised(
     attack_graph: AttackGraph,
     agent_states: AgentStates,
-    live_agents: Set[str],
     node: AttackGraphNode | str,
 ) -> bool:
     """Return True if node is compromised by any attacker agent"""
     node = full_name_or_node_to_node(attack_graph, node)
     return any(
         node in attacker_agent.performed_nodes
-        for attacker_agent in get_attacker_agents(agent_states, live_agents)
+        for attacker_agent in attacker_states(agent_states).values()
     )
 
 
 def compromised_nodes(
     agent_states: AgentStates,
-    live_agents: Set[str],
 ) -> Set[AttackGraphNode]:
     compromised: Set[AttackGraphNode] = set()
-    for attacker in get_attacker_agents(agent_states, live_agents):
+    for attacker in attacker_states(agent_states).values():
         compromised |= attacker.performed_nodes
     return compromised
 

--- a/malsim/scenario/scenario.py
+++ b/malsim/scenario/scenario.py
@@ -14,7 +14,7 @@ A scenario is a combination of:
 from __future__ import annotations
 from collections.abc import Iterable, Mapping, Sequence
 import os
-from dataclasses import asdict, dataclass
+from dataclasses import asdict
 from typing import Any, Optional, TextIO
 import logging
 
@@ -62,7 +62,20 @@ allowed_fields = [
 BASE_SETTINGS = MalSimulatorSettings()
 
 
-@dataclass
+def model_from_multiple_sources(
+    model: Model | dict[str, Any] | str, lang_graph: LanguageGraph
+) -> Model:
+    if isinstance(model, str):
+        model_file = model
+        return Model.load_from_file(model_file, lang_graph)
+    elif isinstance(model, dict):
+        return Model._from_dict(model, lang_graph)
+    elif isinstance(model, Model):
+        return model
+    else:
+        raise ValueError('`model` must be Model, dict, or str (file path)')
+
+
 class Scenario:
     """Scenarios define everything needed to run a simulation"""
 
@@ -77,17 +90,8 @@ class Scenario:
         self._lang_file = lang_file
         self.lang_graph = LanguageGraph.load_from_file(self._lang_file)
 
-        self._model_file = None
-
-        if isinstance(model, str):
-            self._model_file = model
-            self.model = Model.load_from_file(self._model_file, self.lang_graph)
-        elif isinstance(model, dict):
-            self.model = Model._from_dict(model, self.lang_graph)
-        elif isinstance(model, Model):
-            self.model = model
-        else:
-            raise ValueError('`model` must be Model, dict, or str (file path)')
+        self.model = model_from_multiple_sources(model, self.lang_graph)
+        self._model_file = model if isinstance(model, str) else None
 
         attack_graph = create_attack_graph(self.lang_graph, self.model)
 

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -18,7 +18,10 @@ from malsim.mal_simulator import (
     RewardMode,
 )
 from malsim.mal_simulator.attacker_step import attacker_is_terminated, attacker_step
-from malsim.mal_simulator.agent_states import get_attacker_agents, get_defender_agents
+from malsim.mal_simulator.agent_states import (
+    attacker_states,
+    defender_states,
+)
 from malsim.mal_simulator.defender_step import defender_is_terminated, defender_step
 from malsim.mal_simulator import TTCDist
 from malsim import Scenario, run_simulation
@@ -58,7 +61,7 @@ def test_init_with_agent_settings(
     assert sim.agent_states.keys() == {'Attacker1', 'Defender1'}
     assert sim.agent_reward_by_name('Attacker1') == 0.0
     assert sim.agent_reward_by_name('Defender1') == 0.0
-    assert sim._alive_agents == {'Attacker1', 'Defender1'}
+    assert sim.alive_agents == {'Attacker1', 'Defender1'}
 
 
 def test_reset(corelang_lang_graph: LanguageGraph, model: Model) -> None:
@@ -215,12 +218,8 @@ def test_get_agents() -> None:
     sim = MalSimulator.from_scenario(scenario)
     sim.reset()
 
-    assert [
-        a.name for a in get_attacker_agents(sim.agent_states, sim._alive_agents)
-    ] == ['Attacker1']
-    assert [
-        a.name for a in get_defender_agents(sim.agent_states, sim._alive_agents)
-    ] == ['Defender1']
+    assert list(attacker_states(sim.agent_states)) == ['Attacker1']
+    assert list(defender_states(sim.agent_states)) == ['Defender1']
 
 
 def test_attacker_step(corelang_lang_graph: LanguageGraph, model: Model) -> None:
@@ -591,9 +590,7 @@ def test_simulation_done(corelang_lang_graph: LanguageGraph, model: Model) -> No
     assert isinstance(defender_state, MalSimDefenderState)
 
     assert not sim.done()  # simulation is done because truncated
-    assert not defender_is_terminated(
-        sim._agent_states, sim._alive_agents
-    )  # not terminated
+    assert not defender_is_terminated(sim._agent_states)  # not terminated
     assert not attacker_is_terminated(attacker_state)  # not terminated
 
 
@@ -627,7 +624,7 @@ def test_simulation_terminations(
     assert isinstance(defender_state, MalSimDefenderState)
 
     assert sim.done()  # simulation is done because all agents terminated
-    assert defender_is_terminated(sim._agent_states, sim._alive_agents)
+    assert defender_is_terminated(sim._agent_states)
     assert attacker_is_terminated(attacker_state)
 
 


### PR DESCRIPTION
Remove alive agents field to reduce redundancy. (if one is interested in running a function with only live agents, they can filter the states and call the function with that result)