### PR TITLE
feat: remove viability

### DIFF
--- a/malsim/config/sim_settings.py
+++ b/malsim/config/sim_settings.py
@@ -31,9 +31,6 @@ class AttackSurfaceSettings:
     # attack_surface_skip_compromised
     # - if true do not add already compromised nodes to the attack surface
     skip_compromised: bool = True
-    # attack_surface_skip_unviable
-    # - if true do not add unviable nodes to the attack surface
-    skip_unviable: bool = True
     # attack_surface_skip_unnecessary
     # - if true do not add unnecessary nodes to the attack surface
     skip_unnecessary: bool = True

--- a/malsim/envs/legacy/malsim_vectorized_obs_env.py
+++ b/malsim/envs/legacy/malsim_vectorized_obs_env.py
@@ -489,9 +489,6 @@ class MalSimVectorizedObsEnv(ParallelEnv[str, dict[str, Any], dict[str, str]]):
     ) -> None:
         """Update observations of all agents"""
 
-        if not self.sim.sim_settings.uncompromise_untraversable_steps:
-            disabled_nodes = set()
-
         # TODO: Is this correct? All attackers get the same compromised_nodes?
         logger.debug('Enable:\n\t%s', [n.full_name for n in compromised_nodes])
 

--- a/malsim/envs/legacy/malsim_vectorized_obs_env.py
+++ b/malsim/envs/legacy/malsim_vectorized_obs_env.py
@@ -414,7 +414,6 @@ class MalSimVectorizedObsEnv(ParallelEnv[str, dict[str, Any], dict[str, str]]):
     def _update_attacker_obs(
         self,
         compromised_nodes: Set[AttackGraphNode],
-        disabled_nodes: Set[AttackGraphNode],
         attacker_agent: AttackerState,
     ) -> None:
         """Update the observation of the serialized obs attacker"""
@@ -444,21 +443,10 @@ class MalSimVectorizedObsEnv(ParallelEnv[str, dict[str, Any], dict[str, str]]):
                 logger.debug('Enable %s in attacker obs', node.full_name)
                 _enable_node(node, attacker_observation)
 
-        for node in disabled_nodes:
-            if (
-                node in attacker_agent.performed_nodes
-                and node not in attacker_agent.settings.entry_points
-            ):
-                logger.debug('Disable %s in attacker obs', node.full_name)
-                # Mark attacker compromised steps that were
-                # disabled by a defense as disabled in obs
-                node_idx = self.node_to_index(node)
-                attacker_observation['observed_state'][node_idx] = 0
 
     def _update_defender_obs(
         self,
         compromised_nodes: Set[AttackGraphNode],
-        disabled_nodes: Set[AttackGraphNode],
         defender_agent: DefenderState,
     ) -> None:
         """Update the observation of the defender"""
@@ -469,11 +457,6 @@ class MalSimVectorizedObsEnv(ParallelEnv[str, dict[str, Any], dict[str, str]]):
             logger.debug('Enable %s in defender obs', node.full_name)
             node_idx = self.node_to_index(node)
             defender_observation['observed_state'][node_idx] = 1
-
-        for node in disabled_nodes:
-            logger.debug('Disable %s in defender obs', node.full_name)
-            node_idx = self.node_to_index(node)
-            defender_observation['observed_state'][node_idx] = 0
 
     def reset(
         self, seed: int | None = None, options: dict[str, Any] | None = None
@@ -496,7 +479,7 @@ class MalSimVectorizedObsEnv(ParallelEnv[str, dict[str, Any], dict[str, str]]):
             self._agent_infos[agent.name] = self.create_action_mask(agent)
             pre_enabled_nodes |= agent.performed_nodes
 
-        self._update_observations(pre_enabled_nodes, set())
+        self._update_observations(pre_enabled_nodes)
 
         # TODO: should we return copies instead so they are not modified externally?
         return self._agent_observations, self._agent_infos
@@ -504,7 +487,6 @@ class MalSimVectorizedObsEnv(ParallelEnv[str, dict[str, Any], dict[str, str]]):
     def _update_observations(
         self,
         compromised_nodes: Set[AttackGraphNode],
-        disabled_nodes: Set[AttackGraphNode],
     ) -> None:
         """Update observations of all agents"""
 
@@ -513,13 +495,12 @@ class MalSimVectorizedObsEnv(ParallelEnv[str, dict[str, Any], dict[str, str]]):
 
         # TODO: Is this correct? All attackers get the same compromised_nodes?
         logger.debug('Enable:\n\t%s', [n.full_name for n in compromised_nodes])
-        logger.debug('Disable:\n\t%s', [n.full_name for n in disabled_nodes])
 
         for agent in self.sim.agent_states.values():
             if isinstance(agent, AttackerState):
-                self._update_attacker_obs(compromised_nodes, disabled_nodes, agent)
+                self._update_attacker_obs(compromised_nodes, agent)
             elif isinstance(agent, DefenderState):
-                self._update_defender_obs(compromised_nodes, disabled_nodes, agent)
+                self._update_defender_obs(compromised_nodes, agent)
 
     def step(
         self, actions: dict[str, tuple[int, int | None]]
@@ -545,10 +526,9 @@ class MalSimVectorizedObsEnv(ParallelEnv[str, dict[str, Any], dict[str, str]]):
         all_actioned = {
             n for state in states.values() for n in state.step_performed_nodes
         }
-        disabled_nodes = next(iter(states.values())).step_unviable_nodes
 
         self._update_agent_infos()  # Update action masks
-        self._update_observations(all_actioned, set(disabled_nodes))
+        self._update_observations(all_actioned)
 
         observations = self._agent_observations
         rewards = {}

--- a/malsim/envs/legacy/malsim_vectorized_obs_env.py
+++ b/malsim/envs/legacy/malsim_vectorized_obs_env.py
@@ -443,7 +443,6 @@ class MalSimVectorizedObsEnv(ParallelEnv[str, dict[str, Any], dict[str, str]]):
                 logger.debug('Enable %s in attacker obs', node.full_name)
                 _enable_node(node, attacker_observation)
 
-
     def _update_defender_obs(
         self,
         compromised_nodes: Set[AttackGraphNode],

--- a/malsim/mal_simulator/agent_state.py
+++ b/malsim/mal_simulator/agent_state.py
@@ -21,7 +21,5 @@ class AgentState:
     # Contains the order of performed nodes
     performed_nodes_order: Mapping[int, Set[AttackGraphNode]]
 
-    unviable_nodes: Set[AttackGraphNode]
-
     # The iteration this state was created in
     iteration: int

--- a/malsim/mal_simulator/attack_surface.py
+++ b/malsim/mal_simulator/attack_surface.py
@@ -64,14 +64,10 @@ def get_attack_surface(
     from_nodes = from_nodes if from_nodes is not None else performed_nodes
 
     skip_compromised = settings.skip_compromised
-    skip_unviable = settings.skip_unviable
     skip_unnecessary = settings.skip_unnecessary
 
     def uncompromised(node: AttackGraphNode) -> bool:
         return not (skip_compromised and node in performed_nodes)
-
-    def viable(node: AttackGraphNode) -> bool:
-        return not node_is_blocked(sim_state, node)
 
     def necessary(node: AttackGraphNode) -> bool:
         return node_is_necessary(sim_state, node)
@@ -87,8 +83,8 @@ def get_attack_surface(
         is_action = node.causal_mode != 'effect'
         return (
             is_action
+            and not node_is_blocked(sim_state, node)
             and (uncompromised(node) if skip_compromised else True)
-            and (viable(node) if skip_unviable else True)
             and (necessary(node) if skip_unnecessary else True)
             and actionable(node)
             and traversable(node)

--- a/malsim/mal_simulator/attack_surface.py
+++ b/malsim/mal_simulator/attack_surface.py
@@ -9,7 +9,7 @@ from malsim.mal_simulator.graph_utils import (
     node_is_actionable,
     node_is_necessary,
     node_is_traversable,
-    node_is_viable,
+    node_is_blocked,
 )
 
 if TYPE_CHECKING:
@@ -71,7 +71,7 @@ def get_attack_surface(
         return not (skip_compromised and node in performed_nodes)
 
     def viable(node: AttackGraphNode) -> bool:
-        return node_is_viable(sim_state, node)
+        return not node_is_blocked(sim_state, node)
 
     def necessary(node: AttackGraphNode) -> bool:
         return node_is_necessary(sim_state, node)

--- a/malsim/mal_simulator/attacker_state.py
+++ b/malsim/mal_simulator/attacker_state.py
@@ -76,10 +76,3 @@ class AttackerState(AgentState):
             self.previous_state.action_surface if self.previous_state else set()
         )
         return previous_action_surface - self.action_surface
-
-    @property
-    def step_unviable_nodes(self) -> Set[AttackGraphNode]:
-        previous_unviable_nodes = (
-            self.previous_state.unviable_nodes if self.previous_state else set()
-        )
-        return self.unviable_nodes - previous_unviable_nodes

--- a/malsim/mal_simulator/attacker_state_factories.py
+++ b/malsim/mal_simulator/attacker_state_factories.py
@@ -42,12 +42,10 @@ def create_attacker_state(
     ttc_values: Mapping[AttackGraphNode, float],
     impossible_steps: Set[AttackGraphNode],
     new_attempted_nodes: Set[AttackGraphNode] = frozenset(),
-    new_unviable_nodes: Set[AttackGraphNode] = frozenset(),
     previous_state: AttackerState | None = None,
 ) -> AttackerState:
     """
     Update a previous attacker state based on what the agent compromised
-    and what nodes became unviable.
     """
 
     previous_performed_nodes = (
@@ -65,37 +63,23 @@ def create_attacker_state(
         if previous_state
         else dict.fromkeys(sim_state.attack_graph.attack_steps, 0)
     )
-    previous_unviable_nodes = previous_state.unviable_nodes if previous_state else set()
 
     performed_nodes = previous_performed_nodes | new_performed_nodes
     performed_nodes_order = dict(previous_performed_nodes_order)
-    unviable_nodes = previous_unviable_nodes | new_unviable_nodes
     attempted_nodes = previous_attempted_nodes | new_attempted_nodes
     num_attempts = dict(previous_num_attempts)
     for node in new_attempted_nodes:
         num_attempts[node] += 1
 
-    # Build on previous attack surface (for performance)
-    action_surface_additions = (
-        get_attack_surface(
-            attack_surface_settings,
-            sim_state,
-            attacker_settings.actionable_steps,
-            previous_performed_nodes | new_performed_nodes,
-            from_nodes=new_performed_nodes,
-        )
-        - previous_action_surface
+    action_surface = get_attack_surface(
+        attack_surface_settings,
+        sim_state,
+        attacker_settings.actionable_steps,
+        previous_performed_nodes | new_performed_nodes,
     )
 
     if not previous_state and not sim_state.settings.compromise_entrypoints_at_start:
-        action_surface_additions |= attacker_settings.entry_points
-
-    action_surface_removals = set(
-        (new_unviable_nodes & previous_action_surface) | new_performed_nodes
-    )
-    action_surface = frozenset(
-        (previous_action_surface - action_surface_removals) | action_surface_additions
-    )
+        action_surface |= attacker_settings.entry_points
 
     iteration = previous_state.iteration if previous_state else 0
     if new_performed_nodes:
@@ -109,7 +93,6 @@ def create_attacker_state(
         settings=attacker_settings,
         ttc_values=ttc_values,
         impossible_steps=impossible_steps,
-        unviable_nodes=unviable_nodes,
         performed_nodes=frozenset(performed_nodes),
         attempted_nodes=frozenset(attempted_nodes),
         action_surface=action_surface,

--- a/malsim/mal_simulator/attacker_state_factories.py
+++ b/malsim/mal_simulator/attacker_state_factories.py
@@ -57,7 +57,6 @@ def create_attacker_state(
     previous_attempted_nodes = (
         previous_state.attempted_nodes if previous_state else set()
     )
-    previous_action_surface = previous_state.action_surface if previous_state else set()
     previous_num_attempts = (
         previous_state.num_attempts
         if previous_state

--- a/malsim/mal_simulator/attacker_step.py
+++ b/malsim/mal_simulator/attacker_step.py
@@ -9,7 +9,7 @@ from maltoolbox.attackgraph import AttackGraphNode
 from malsim.mal_simulator.attack_surface import get_effects_of_attack_step
 from malsim.mal_simulator.graph_utils import (
     node_is_traversable,
-    node_is_viable,
+    node_is_blocked,
 )
 from malsim.mal_simulator.state_query import node_ttc_value
 from malsim.config.sim_settings import TTCMode
@@ -138,12 +138,15 @@ def attacker_step(
         )
 
         if node in agent.settings.entry_points:
-            # Entrypoints can be compromised as long as they are viable
-            can_compromise = node_is_viable(sim_state, node)
+            # Entrypoints can always be compromised
+            # TODO: should this actually be the case?
+            can_compromise = True
         else:
-            # Otherwise it is limited by action surface and traversability
-            can_compromise = node in agent.action_surface and node_is_traversable(
-                sim_state, agent.performed_nodes, node
+            # Otherwise attacker is limited by attack surface and traversability
+            can_compromise = (
+                node in agent.action_surface
+                and not node_is_blocked(sim_state, node)
+                and node_is_traversable(sim_state, agent.performed_nodes, node)
             )
 
         if can_compromise:

--- a/malsim/mal_simulator/defender_state.py
+++ b/malsim/mal_simulator/defender_state.py
@@ -71,10 +71,3 @@ class DefenderState(AgentState):
             self.previous_state.action_surface if self.previous_state else set()
         )
         return previous_action_surface - self.action_surface
-
-    @property
-    def step_unviable_nodes(self) -> Set[AttackGraphNode]:
-        previous_unviable_nodes = (
-            self.previous_state.unviable_nodes if self.previous_state else set()
-        )
-        return self.unviable_nodes - previous_unviable_nodes

--- a/malsim/mal_simulator/defender_state_factories.py
+++ b/malsim/mal_simulator/defender_state_factories.py
@@ -19,7 +19,6 @@ def create_defender_state(
     defender_settings: DefenderSettings,
     new_compromised_nodes: Set[AttackGraphNode] = frozenset(),
     new_enabled_defenses: Set[AttackGraphNode] = frozenset(),
-    new_unviable_nodes: Set[AttackGraphNode] = frozenset(),
     previous_state: DefenderState | None = None,
 ) -> DefenderState:
     """
@@ -39,7 +38,6 @@ def create_defender_state(
     performed_nodes_order = (
         dict(previous_state.performed_nodes_order) if previous_state else {}
     )
-    previous_unviable_nodes = previous_state.unviable_nodes if previous_state else set()
 
     action_surface = (
         get_defense_surface(sim_state, defender_settings.actionable_steps)
@@ -64,7 +62,6 @@ def create_defender_state(
         sim_state=sim_state,
         settings=defender_settings,
         performed_nodes=frozenset(previous_enabled_defenses | new_enabled_defenses),
-        unviable_nodes=frozenset(previous_unviable_nodes | new_unviable_nodes),
         compromised_nodes=frozenset(previous_compromised_nodes | new_compromised_nodes),
         observed_nodes=frozenset(previous_observed_nodes | new_observed_nodes),
         action_surface=frozenset(action_surface),

--- a/malsim/mal_simulator/defender_step.py
+++ b/malsim/mal_simulator/defender_step.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from collections.abc import Set
 from typing import TYPE_CHECKING
 from maltoolbox.attackgraph import AttackGraphNode
 import logging

--- a/malsim/mal_simulator/defender_step.py
+++ b/malsim/mal_simulator/defender_step.py
@@ -7,7 +7,6 @@ import logging
 
 from malsim.mal_simulator.agent_states import attacker_states
 from malsim.mal_simulator.attacker_step import attacker_is_terminated
-from malsim.mal_simulator.graph_processing import make_node_unviable
 from malsim.mal_simulator.simulator_state import MalSimulatorState
 
 if TYPE_CHECKING:
@@ -31,7 +30,7 @@ def defender_step(
     sim_state: MalSimulatorState,
     agent: DefenderState,
     nodes: list[AttackGraphNode],
-) -> tuple[list[AttackGraphNode], Set[AttackGraphNode]]:
+) -> list[AttackGraphNode]:
     """Enable defense step nodes with defender.
 
     Args:
@@ -39,12 +38,10 @@ def defender_step(
     nodes - the defense step nodes to enable
 
     Returns a tuple of a list and a set, `enabled_defenses`
-    and `attack_steps_made_unviable`.
     """
 
     logger.debug('Stepping with %s', agent.name)
     enabled_defenses: list[AttackGraphNode] = []
-    attack_steps_made_unviable: Set[AttackGraphNode] = set()
 
     for node in nodes:
         assert node == sim_state.attack_graph.nodes[node.id], (
@@ -64,19 +61,10 @@ def defender_step(
             )
         else:
             enabled_defenses.append(node)
-            sim_state.graph_state.viability_per_node, made_unviable = (
-                make_node_unviable(
-                    node,
-                    # TODO make this immutable
-                    dict(sim_state.graph_state.viability_per_node),
-                    sim_state.graph_state.impossible_attack_steps,
-                )
-            )
-            attack_steps_made_unviable |= made_unviable
             logger.info(
                 'Defender agent "%s" enabled "%s"',
                 agent.name,
                 node.full_name,
             )
 
-    return enabled_defenses, attack_steps_made_unviable
+    return enabled_defenses

--- a/malsim/mal_simulator/defense_surface.py
+++ b/malsim/mal_simulator/defense_surface.py
@@ -3,7 +3,7 @@ from collections.abc import Set
 from typing import TYPE_CHECKING
 
 from malsim.config.node_property_rule import NodePropertyRule
-from malsim.mal_simulator.graph_utils import node_is_actionable, node_is_viable
+from malsim.mal_simulator.graph_utils import node_is_actionable, node_is_blocked
 
 if TYPE_CHECKING:
     from maltoolbox.attackgraph import AttackGraphNode
@@ -25,6 +25,7 @@ def get_defense_surface(
         node
         for node in sim_state.attack_graph.defense_steps
         if node_is_actionable(agent_actionability_rule, node)
-        and node_is_viable(sim_state, node)
+        and not node_is_blocked(sim_state, node)
+        and node not in sim_state.enabled_defenses
         and 'suppress' not in node.tags
     }

--- a/malsim/mal_simulator/graph_processing.py
+++ b/malsim/mal_simulator/graph_processing.py
@@ -4,7 +4,7 @@ MAL Simulator Attack Graph Processing Submodule
 This submodule is meant to process the attack graph before running the
 simulation.
 Currently it adds the following information to nodes:
-- Viability = Determine if a node can be traversed under any circumstances or
+- Viability (deprecated) = Determine if a node can be traversed under any circumstances or
   if the model structure, defenses or ttcs makes it unviable.
 - Necessity = Determine if a node is necessary for the attacker or if the
   model structure means it is not needed (it behaves as if it were already

--- a/malsim/mal_simulator/graph_processing.py
+++ b/malsim/mal_simulator/graph_processing.py
@@ -4,8 +4,8 @@ MAL Simulator Attack Graph Processing Submodule
 This submodule is meant to process the attack graph before running the
 simulation.
 Currently it adds the following information to nodes:
-- Viability (deprecated) = Determine if a node can be traversed under any circumstances or
-  if the model structure, defenses or ttcs makes it unviable.
+- Viability (deprecated) = Determine if a node can be traversed under any circumstances
+  or if the model structure, defenses or ttcs makes it unviable.
 - Necessity = Determine if a node is necessary for the attacker or if the
   model structure means it is not needed (it behaves as if it were already
   compromised) to compromise children attack steps.

--- a/malsim/mal_simulator/graph_state.py
+++ b/malsim/mal_simulator/graph_state.py
@@ -11,10 +11,7 @@ from malsim.mal_simulator.ttc_utils import (
     get_pre_enabled_defenses,
     get_impossible_attack_steps,
 )
-from malsim.mal_simulator.graph_processing import (
-    calculate_viability,
-    calculate_necessity,
-)
+from malsim.mal_simulator.graph_processing import calculate_necessity
 
 
 from malsim.config.sim_settings import MalSimulatorSettings
@@ -27,7 +24,6 @@ class GraphState:
     ttc_values: Mapping[AttackGraphNode, float]
     pre_enabled_defenses: Set[AttackGraphNode]
     impossible_attack_steps: Set[AttackGraphNode]
-    viability_per_node: Mapping[AttackGraphNode, bool]
     necessity_per_node: Mapping[AttackGraphNode, bool]
 
 
@@ -36,8 +32,8 @@ def compute_initial_graph_state(
 ) -> GraphState:
     """Compute attack graph initial state based on probabilities and settings
 
-    Compute ttc values, enabled defenses, impossible attack steps,
-    viability and necessity for an attack graph based on given settings.
+    Compute ttc values, enabled defenses, impossible attack steps
+    and necessity for an attack graph based on given settings.
     """
 
     # TTC (Time to compromise) for each attack step
@@ -55,15 +51,11 @@ def compute_initial_graph_state(
         # These steps will not be traversable
         impossible_attack_steps = get_impossible_attack_steps(graph.attack_steps, rng)
 
-    viability_per_node = calculate_viability(
-        graph, enabled_defenses, impossible_attack_steps
-    )
     necessity_per_node = calculate_necessity(graph, enabled_defenses)
 
     return GraphState(
         ttc_values=ttc_values,
         pre_enabled_defenses=enabled_defenses,
         impossible_attack_steps=impossible_attack_steps,
-        viability_per_node=viability_per_node,
         necessity_per_node=necessity_per_node,
     )

--- a/malsim/mal_simulator/graph_utils.py
+++ b/malsim/mal_simulator/graph_utils.py
@@ -27,14 +27,12 @@ def node_is_blocked(sim_state: MalSimulatorState, node: AttackGraphNode | str) -
 
     node = full_name_or_node_to_node(sim_state.attack_graph, node)
     if node.type == 'and':
-        return (
-            node in sim_state.graph_state.impossible_attack_steps or
-            any(_node_blocks_children(parent) for parent in node.parents)
+        return node in sim_state.graph_state.impossible_attack_steps or any(
+            _node_blocks_children(parent) for parent in node.parents
         )
     elif node.type == 'or':
-        return (
-            node in sim_state.graph_state.impossible_attack_steps or
-            any(_node_blocks_children(parent) for parent in node.parents)
+        return node in sim_state.graph_state.impossible_attack_steps or any(
+            _node_blocks_children(parent) for parent in node.parents
         )
     else:
         return False

--- a/malsim/mal_simulator/graph_utils.py
+++ b/malsim/mal_simulator/graph_utils.py
@@ -31,7 +31,7 @@ def node_is_blocked(sim_state: MalSimulatorState, node: AttackGraphNode | str) -
             _node_blocks_children(parent) for parent in node.parents
         )
     elif node.type == 'or':
-        return node in sim_state.graph_state.impossible_attack_steps or any(
+        return node in sim_state.graph_state.impossible_attack_steps or all(
             _node_blocks_children(parent) for parent in node.parents
         )
     else:

--- a/malsim/mal_simulator/graph_utils.py
+++ b/malsim/mal_simulator/graph_utils.py
@@ -16,7 +16,7 @@ def node_is_blocked(sim_state: MalSimulatorState, node: AttackGraphNode | str) -
         match node.type:
             case 'exist':
                 assert isinstance(node.existence_status, bool)
-                return node.existence_status
+                return not node.existence_status
             case 'notExist':
                 assert isinstance(node.existence_status, bool)
                 return node.existence_status
@@ -27,9 +27,15 @@ def node_is_blocked(sim_state: MalSimulatorState, node: AttackGraphNode | str) -
 
     node = full_name_or_node_to_node(sim_state.attack_graph, node)
     if node.type == 'and':
-        return any(_node_blocks_children(parent) for parent in node.parents)
+        return (
+            node in sim_state.graph_state.impossible_attack_steps or
+            any(_node_blocks_children(parent) for parent in node.parents)
+        )
     elif node.type == 'or':
-        return all(_node_blocks_children(parent) for parent in node.parents)
+        return (
+            node in sim_state.graph_state.impossible_attack_steps or
+            any(_node_blocks_children(parent) for parent in node.parents)
+        )
     else:
         return False
 

--- a/malsim/mal_simulator/graph_utils.py
+++ b/malsim/mal_simulator/graph_utils.py
@@ -9,10 +9,29 @@ from malsim.mal_simulator.node_getters import full_name_or_node_to_node
 from malsim.mal_simulator.simulator_state import MalSimulatorState
 
 
-def node_is_viable(sim_state: MalSimulatorState, node: AttackGraphNode | str) -> bool:
-    """Get viability of a node"""
+def node_is_blocked(sim_state: MalSimulatorState, node: AttackGraphNode | str) -> bool:
+    """Get blocked status of a node"""
+
+    def _node_blocks_children(node: AttackGraphNode) -> bool:
+        match node.type:
+            case 'exist':
+                assert isinstance(node.existence_status, bool)
+                return node.existence_status
+            case 'notExist':
+                assert isinstance(node.existence_status, bool)
+                return node.existence_status
+            case 'defense':
+                return node in sim_state.enabled_defenses
+            case _:
+                return False
+
     node = full_name_or_node_to_node(sim_state.attack_graph, node)
-    return sim_state.graph_state.viability_per_node[node]
+    if node.type == 'and':
+        return any(_node_blocks_children(parent) for parent in node.parents)
+    elif node.type == 'or':
+        return all(_node_blocks_children(parent) for parent in node.parents)
+    else:
+        return False
 
 
 def node_is_necessary(
@@ -73,7 +92,7 @@ def node_is_traversable(
 
     return (
         is_attack_step(node)
-        and node_is_viable(sim_state, node)
+        and not node_is_blocked(sim_state, node)
         and parents_reached(node)
         and is_and_or_traversable(node)
     )

--- a/malsim/mal_simulator/simulator.py
+++ b/malsim/mal_simulator/simulator.py
@@ -216,7 +216,6 @@ class MalSimulator:
 
         Args:
             scenario - a Scenario object or a path to a scenario file
-            sim_settings - settings to use in the simulator
             send_to_api - whether to send data to GUI REST API or not
         """
         return create_simulator_from_scenario(scenario, send_to_api)

--- a/malsim/mal_simulator/simulator.py
+++ b/malsim/mal_simulator/simulator.py
@@ -56,13 +56,14 @@ from malsim.mal_simulator.defender_state_factories import create_defender_state
 from malsim.mal_simulator.simulator_state import (
     MalSimulatorState,
     create_simulator_state,
+    update_simulator_state,
 )
 from malsim.config.sim_settings import MalSimulatorSettings, RewardMode
 from malsim.mal_simulator.graph_utils import (
     node_is_actionable,
     node_is_necessary,
     node_is_traversable,
-    node_is_viable,
+    node_is_blocked,
     node_reward,
 )
 from malsim.mal_simulator.state_query import (
@@ -282,8 +283,8 @@ class MalSimulator:
             false_negative_rates_rule = agent.false_negative_rates
         return node_false_negative_rate(node, false_negative_rates_rule)
 
-    def node_is_viable(self, node: AttackGraphNode | str) -> bool:
-        return node_is_viable(self.sim_state, node)
+    def node_is_blocked(self, node: AttackGraphNode | str) -> bool:
+        return node_is_blocked(self.sim_state, node)
 
     def node_is_necessary(self, node: AttackGraphNode | str) -> bool:
         return node_is_necessary(self.sim_state, node)
@@ -440,6 +441,7 @@ def reset(
         agent_settings,
         rng,
     )
+
     # Upload initial state to the REST API
     if rest_api_client:
         rest_api_client.upload_initial_state(attack_graph)
@@ -505,6 +507,8 @@ def step(
         recording[current_iteration][defender_state.name] = list(enabled)
         step_enabled_defenses += enabled
         step_nodes_made_unviable |= unviable
+
+    sim_state = update_simulator_state(sim_state, set(step_enabled_defenses))
 
     # Perform attacker actions afterwards
     for attacker_state in attacker_states(agent_states).values():

--- a/malsim/mal_simulator/simulator.py
+++ b/malsim/mal_simulator/simulator.py
@@ -491,7 +491,6 @@ def step(
     # Populate these from the results for all agents' actions.
     step_compromised_nodes: list[AttackGraphNode] = []
     step_enabled_defenses: list[AttackGraphNode] = []
-    step_nodes_made_unviable: Set[AttackGraphNode] = set()
     current_iteration = 0
 
     # Perform defender actions first
@@ -501,12 +500,11 @@ def step(
                 sim_state.attack_graph, actions.get(defender_state.name, [])
             )
         )
-        enabled, unviable = defender_step(sim_state, defender_state, agent_actions)
+        enabled = defender_step(sim_state, defender_state, agent_actions)
         current_iteration = defender_state.iteration
 
         recording[current_iteration][defender_state.name] = list(enabled)
         step_enabled_defenses += enabled
-        step_nodes_made_unviable |= unviable
 
     sim_state = update_simulator_state(sim_state, set(step_enabled_defenses))
 
@@ -532,7 +530,6 @@ def step(
             name=attacker_state.name,
             new_performed_nodes=frozenset(agent_compromised),
             new_attempted_nodes=frozenset(agent_attempted),
-            new_unviable_nodes=step_nodes_made_unviable,
             previous_state=attacker_state,
             ttc_values=attacker_state.ttc_values,
             impossible_steps=attacker_state.impossible_steps,
@@ -548,7 +545,6 @@ def step(
             defender_settings=defender_state.settings,
             new_compromised_nodes=set(step_compromised_nodes),
             new_enabled_defenses=set(step_enabled_defenses),
-            new_unviable_nodes=step_nodes_made_unviable,
             previous_state=defender_state,
             rng=rng,
         )

--- a/malsim/mal_simulator/simulator_state.py
+++ b/malsim/mal_simulator/simulator_state.py
@@ -1,8 +1,7 @@
+from collections.abc import Set
 from dataclasses import dataclass
 
-
-from maltoolbox.attackgraph import AttackGraph
-
+from maltoolbox.attackgraph import AttackGraph, AttackGraphNode
 
 from malsim.config.sim_settings import MalSimulatorSettings
 from malsim.mal_simulator.graph_state import GraphState
@@ -13,6 +12,7 @@ class MalSimulatorState:
     attack_graph: AttackGraph
     settings: MalSimulatorSettings
     graph_state: GraphState
+    enabled_defenses: Set[AttackGraphNode]
 
 
 def create_simulator_state(
@@ -24,4 +24,17 @@ def create_simulator_state(
         attack_graph,
         sim_settings,
         graph_state,
+        enabled_defenses=graph_state.pre_enabled_defenses,
+    )
+
+
+def update_simulator_state(
+    sim_state: MalSimulatorState,
+    enabled_defenses: Set[AttackGraphNode],
+) -> MalSimulatorState:
+    return MalSimulatorState(
+        sim_state.attack_graph,
+        sim_state.settings,
+        sim_state.graph_state,
+        enabled_defenses=enabled_defenses | sim_state.enabled_defenses,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,6 +99,7 @@ def dummy_lang_graph(corelang_lang_graph: LanguageGraph) -> LanguageGraph:
     LanguageGraphAsset and LanguageGraphAttackStep
     """
     lang_graph = LanguageGraph()
+    lang_graph.metadata = {}
     dummy_asset = LanguageGraphAsset(name='DummyAsset')
     lang_graph.assets['DummyAsset'] = dummy_asset
     dummy_or_attack_step_node = LanguageGraphAttackStep(

--- a/tests/envs/test_example_scenarios.py
+++ b/tests/envs/test_example_scenarios.py
@@ -83,8 +83,8 @@ def test_bfs_vs_bfs_state_and_reward_first() -> None:
         total_reward_defender += sim.agent_reward(defender_state)
         total_reward_attacker += sim.agent_reward(attacker_state)
 
-    assert defender_state.iteration == 45
-    assert attacker_state.iteration == 45
+    assert defender_state.iteration == 41
+    assert attacker_state.iteration == 41
 
     # Make sure the actions performed were as expected
     assert attacker_actions == [
@@ -111,8 +111,6 @@ def test_bfs_vs_bfs_state_and_reward_first() -> None:
         'Internet:successfulEavesdrop',
         'Internet:bypassAdversaryInTheMiddleDefense',
         'Internet:successfulAdversaryInTheMiddle',
-        'ConnectionRule Internet->Linux System:restrictedBypassed',
-        'ConnectionRule Internet->Linux System:payloadInspectionBypassed',
         'Linux system:networkConnectUninspected',
         'Linux system:networkConnectInspected',
         'ConnectionRule Internet->Linux System:reverseReach',
@@ -120,9 +118,7 @@ def test_bfs_vs_bfs_state_and_reward_first() -> None:
         'ConnectionRule Internet->Linux System:connectToApplicationsInspected',
         'ConnectionRule Internet->Linux System:accessNetworksUninspected',
         'Linux system:denyFromNetworkingAsset',
-        'Internet:eavesdropDefenseBypassed',
         'Internet:eavesdrop',
-        'Internet:adversaryInTheMiddleDefenseBypassed',
         'Internet:adversaryInTheMiddle',
         'Linux system:attemptUseVulnerability',
         'Linux system:networkConnect',
@@ -160,7 +156,7 @@ def test_bfs_vs_bfs_state_and_reward_first() -> None:
     assert sim.agent_reward(defender_state) == -50
 
     assert total_reward_attacker == 0
-    assert total_reward_defender == -2200
+    assert total_reward_defender == -2000
 
 
 def test_bfs_vs_bfs_state_and_reward_per_step_ttc() -> None:
@@ -244,10 +240,13 @@ def test_bfs_vs_bfs_state_and_reward_per_step_ttc() -> None:
         'ConnectionRule:1:attemptConnectToApplicationsUninspected',
         'ConnectionRule:1:attemptAccessNetworksInspected',
         'ConnectionRule:1:attemptConnectToApplicationsInspected',
-        'Program 1:bypassContainerization',
+        'Program 1:specificAccessRead',
+        'Program 1:specificAccessDelete',
+        'Program 1:attemptUseVulnerability',
+        'Program 1:attemptAuthorizedApplicationRespondConnectThroughData',
+        'Program 1:specificAccessModify',
         'ConnectionRule:1:successfulAccessNetworksUninspected',
         'ConnectionRule:1:bypassRestricted',
-        'ConnectionRule:1:bypassPayloadInspection',
         'ConnectionRule:1:connectToApplicationsUninspected',
         'ConnectionRule:1:successfulAccessNetworksInspected',
         'ConnectionRule:1:connectToApplicationsInspected',
@@ -259,53 +258,52 @@ def test_bfs_vs_bfs_state_and_reward_per_step_ttc() -> None:
         'Program 1:softwareProductVulnerabilityNetworkAccessAchieved',
         'Program 1:networkConnect',
         'Program 1:specificAccessNetworkConnect',
-        'Program 1:attemptUseVulnerability',
         'Network:2:accessInspected',
-        'Network:2:accessNetworkData',
+        'Network:2:networkForwardingUninspected',
         'Network:2:attemptReverseReach',
         'ConnectionRule:3:attemptConnectToApplicationsUninspected',
-        'Network:2:networkForwardingUninspected',
         'Network:2:deny',
-        'Network:2:networkForwardingInspected',
+        'Network:2:accessNetworkData',
         'ConnectionRule:3:attemptConnectToApplicationsInspected',
-        'Network:2:attemptAdversaryInTheMiddle',
-        'Network:2:attemptEavesdrop',
+        'Network:2:networkForwardingInspected',
+        'ConnectionRule:3:attemptAccessNetworksUninspected',
         'Network:2:reverseReach',
-        'ConnectionRule:3:bypassPayloadInspection',
         'ConnectionRule:3:connectToApplicationsUninspected',
         'ConnectionRule:3:bypassRestricted',
-        'ConnectionRule:3:attemptAccessNetworksUninspected',
+        'ConnectionRule:3:bypassPayloadInspection',
         'ConnectionRule:3:attemptDeny',
         'ConnectionRule:1:attemptDeny',
-        'ConnectionRule:3:attemptAccessNetworksInspected',
+        'Network:2:attemptAdversaryInTheMiddle',
+        'Network:2:attemptEavesdrop',
         'ConnectionRule:3:connectToApplicationsInspected',
-        'Network:2:bypassAdversaryInTheMiddleDefense',
-        'Network:2:successfulAdversaryInTheMiddle',
-        'Network:2:successfulEavesdrop',
-        'Network:2:bypassEavesdropDefense',
-        'ConnectionRule:1:attemptReverseReach',
-        'ConnectionRule:3:attemptReverseReach',
-        'Program 2:networkConnectInspected',
-        'Program 2:networkConnectUninspected',
+        'ConnectionRule:3:attemptAccessNetworksInspected',
         'ConnectionRule:3:successfulAccessNetworksUninspected',
+        'ConnectionRule:3:attemptReverseReach',
+        'ConnectionRule:1:attemptReverseReach',
+        'Program 2:networkConnectUninspected',
+        'Program 2:networkConnectInspected',
         'ConnectionRule:3:deny',
         'ConnectionRule:1:deny',
+        'Network:2:successfulAdversaryInTheMiddle',
+        'Network:2:bypassAdversaryInTheMiddleDefense',
+        'Network:2:bypassEavesdropDefense',
+        'Network:2:successfulEavesdrop',
         'ConnectionRule:3:successfulAccessNetworksInspected',
-        'Network:2:adversaryInTheMiddle',
-        'Network:2:eavesdrop',
-        'ConnectionRule:1:reverseReach',
-        'ConnectionRule:3:reverseReach',
-        'Program 2:specificAccessNetworkConnect',
-        'Program 2:networkConnect',
-        'Program 2:attemptUseVulnerability',
-        'Program 2:softwareProductVulnerabilityNetworkAccessAchieved',
         'ConnectionRule:3:accessNetworksUninspected',
+        'ConnectionRule:3:reverseReach',
+        'ConnectionRule:1:reverseReach',
+        'Program 2:networkConnect',
+        'Program 2:softwareProductVulnerabilityNetworkAccessAchieved',
+        'Program 2:specificAccessNetworkConnect',
+        'Program 2:attemptUseVulnerability',
         'Program 2:denyFromNetworkingAsset',
         'Program 1:denyFromNetworkingAsset',
+        'Network:2:adversaryInTheMiddle',
+        'Network:2:eavesdrop',
         'ConnectionRule:3:accessNetworksInspected',
-        'Program 1:attemptReverseReach',
         'Program 2:attemptReverseReach',
-        'Program 2:attemptDeny',
+        'Program 1:attemptReverseReach',
+        'Program 2:attemptDeny'
     ]
 
     assert defender_actions == [
@@ -337,7 +335,7 @@ def test_bfs_vs_bfs_state_and_reward_per_step_ttc() -> None:
     assert sim.agent_reward(defender_state) == -19
 
     assert total_reward_attacker == -attacker_failed_steps
-    assert total_reward_defender == -17143.0
+    assert total_reward_defender == -16459
 
 
 def test_bfs_vs_bfs_state_and_reward_per_step_effort_based() -> None:
@@ -398,8 +396,8 @@ def test_bfs_vs_bfs_state_and_reward_per_step_effort_based() -> None:
         total_reward_defender += sim.agent_reward(defender_state)
         total_reward_attacker += sim.agent_reward(attacker_state)
 
-    assert attacker_state.iteration == 37
-    assert defender_state.iteration == 37
+    assert attacker_state.iteration == 96
+    assert defender_state.iteration == 96
 
     # Make sure the actions performed were as expected
     assert attacker_actions == [
@@ -414,12 +412,67 @@ def test_bfs_vs_bfs_state_and_reward_per_step_effort_based() -> None:
         'ConnectionRule:1:attemptAccessNetworksInspected',
         # Below steps are because of persistance
         'ConnectionRule:1:attemptConnectToApplicationsInspected',
-        'Program 1:bypassContainerization',
-        'ConnectionRule:1:bypassRestricted',
+        'Program 1:specificAccessRead',
+        'Program 1:specificAccessDelete',
+        'Program 1:attemptUseVulnerability',
+        'Program 1:attemptAuthorizedApplicationRespondConnectThroughData',
+        'Program 1:specificAccessModify',
+        'ConnectionRule:1:successfulAccessNetworksUninspected',
+        'ConnectionRule:1:connectToApplicationsUninspected',
+        'ConnectionRule:1:bypassPayloadInspection',
+        'ConnectionRule:1:successfulAccessNetworksInspected',
         'ConnectionRule:1:connectToApplicationsInspected',
+        'ConnectionRule:1:accessNetworksUninspected',
+        'Program 1:networkConnectUninspected',
         'Program 1:networkConnectInspected',
+        'ConnectionRule:1:accessNetworksInspected',
+        'Network:2:accessUninspected',
+        'Program 1:softwareProductVulnerabilityNetworkAccessAchieved',
         'Program 1:networkConnect',
         'Program 1:specificAccessNetworkConnect',
+        'Network:2:accessInspected',
+        'Network:2:networkForwardingUninspected',
+        'Network:2:attemptReverseReach',
+        'ConnectionRule:3:attemptConnectToApplicationsUninspected',
+        'Network:2:deny',
+        'Network:2:accessNetworkData',
+        'ConnectionRule:3:attemptConnectToApplicationsInspected',
+        'Network:2:networkForwardingInspected',
+        'ConnectionRule:3:attemptAccessNetworksUninspected',
+        'Network:2:reverseReach',
+        'ConnectionRule:3:connectToApplicationsUninspected',
+        'ConnectionRule:1:attemptDeny',
+        'ConnectionRule:3:attemptDeny',
+        'Network:2:attemptAdversaryInTheMiddle',
+        'Network:2:attemptEavesdrop',
+        'ConnectionRule:3:connectToApplicationsInspected',
+        'ConnectionRule:3:attemptAccessNetworksInspected',
+        'ConnectionRule:3:successfulAccessNetworksUninspected',
+        'ConnectionRule:3:attemptReverseReach',
+        'ConnectionRule:1:attemptReverseReach',
+        'Program 2:networkConnectInspected',
+        'Program 2:networkConnectUninspected',
+        'ConnectionRule:1:deny',
+        'ConnectionRule:3:deny',
+        'Network:2:successfulAdversaryInTheMiddle',
+        'Network:2:successfulEavesdrop',
+        'Network:2:bypassEavesdropDefense',
+        'ConnectionRule:3:successfulAccessNetworksInspected',
+        'ConnectionRule:3:accessNetworksUninspected',
+        'ConnectionRule:3:reverseReach',
+        'ConnectionRule:1:reverseReach',
+        'Program 2:networkConnect',
+        'Program 2:specificAccessNetworkConnect',
+        'Program 2:softwareProductVulnerabilityNetworkAccessAchieved',
+        'Program 2:attemptUseVulnerability',
+        'Program 1:denyFromNetworkingAsset',
+        'Program 2:denyFromNetworkingAsset',
+        'Network:2:adversaryInTheMiddle',
+        'Network:2:eavesdrop',
+        'ConnectionRule:3:accessNetworksInspected',
+        'Program 2:attemptReverseReach',
+        'Program 1:attemptReverseReach',
+        'Program 2:attemptDeny'
     ]
 
     assert defender_actions == [
@@ -451,7 +504,7 @@ def test_bfs_vs_bfs_state_and_reward_per_step_effort_based() -> None:
     assert sim.agent_reward(defender_state) == -19
 
     assert total_reward_attacker == -attacker_failed_steps
-    assert total_reward_defender == -575.0
+    assert total_reward_defender == -1696
 
 
 def test_bfs_vs_bfs_state_and_reward_expected_value_ttc() -> None:
@@ -514,8 +567,8 @@ def test_bfs_vs_bfs_state_and_reward_expected_value_ttc() -> None:
         total_reward_defender += sim.agent_reward(defender_state)
         total_reward_attacker += sim.agent_reward(attacker_state)
 
-    assert attacker_state.iteration == 116
-    assert defender_state.iteration == 116
+    assert attacker_state.iteration == 380
+    assert defender_state.iteration == 380
 
     # Make sure the actions performed were as expected
     assert attacker_actions == [
@@ -529,11 +582,69 @@ def test_bfs_vs_bfs_state_and_reward_expected_value_ttc() -> None:
         'ConnectionRule:1:attemptConnectToApplicationsUninspected',
         'ConnectionRule:1:attemptAccessNetworksInspected',
         'ConnectionRule:1:attemptConnectToApplicationsInspected',
-        'ConnectionRule:1:bypassRestricted',
+        'Program 1:attemptAuthorizedApplicationRespondConnectThroughData',
+        'Program 1:specificAccessModify',
+        'Program 1:attemptUseVulnerability',
+        'Program 1:bypassContainerization',
+        'Program 1:specificAccessRead',
+        'Program 1:specificAccessDelete',
+        'ConnectionRule:1:successfulAccessNetworksUninspected',
+        'ConnectionRule:1:connectToApplicationsUninspected',
+        'ConnectionRule:1:bypassPayloadInspection',
+        'ConnectionRule:1:successfulAccessNetworksInspected',
         'ConnectionRule:1:connectToApplicationsInspected',
+        'ConnectionRule:1:accessNetworksUninspected',
+        'Program 1:networkConnectUninspected',
         'Program 1:networkConnectInspected',
+        'ConnectionRule:1:accessNetworksInspected',
+        'Network:2:accessUninspected',
+        'Program 1:softwareProductVulnerabilityNetworkAccessAchieved',
         'Program 1:networkConnect',
         'Program 1:specificAccessNetworkConnect',
+        'Network:2:accessInspected',
+        'Network:2:networkForwardingUninspected',
+        'Network:2:attemptReverseReach',
+        'ConnectionRule:3:attemptConnectToApplicationsUninspected',
+        'Network:2:deny',
+        'Network:2:accessNetworkData',
+        'ConnectionRule:3:attemptConnectToApplicationsInspected',
+        'Network:2:networkForwardingInspected',
+        'ConnectionRule:3:attemptAccessNetworksUninspected',
+        'Network:2:reverseReach',
+        'ConnectionRule:3:bypassPayloadInspection',
+        'ConnectionRule:3:connectToApplicationsUninspected',
+        'ConnectionRule:3:attemptDeny',
+        'ConnectionRule:1:attemptDeny',
+        'Network:2:attemptAdversaryInTheMiddle',
+        'Network:2:attemptEavesdrop',
+        'ConnectionRule:3:connectToApplicationsInspected',
+        'ConnectionRule:3:attemptAccessNetworksInspected',
+        'ConnectionRule:3:successfulAccessNetworksUninspected',
+        'ConnectionRule:3:attemptReverseReach',
+        'ConnectionRule:1:attemptReverseReach',
+        'Program 2:networkConnectInspected',
+        'Program 2:networkConnectUninspected',
+        'ConnectionRule:3:deny',
+        'ConnectionRule:1:deny',
+        'Network:2:bypassAdversaryInTheMiddleDefense',
+        'Network:2:successfulAdversaryInTheMiddle',
+        'Network:2:successfulEavesdrop',
+        'ConnectionRule:3:successfulAccessNetworksInspected',
+        'ConnectionRule:3:accessNetworksUninspected',
+        'ConnectionRule:3:reverseReach',
+        'ConnectionRule:1:reverseReach',
+        'Program 2:specificAccessNetworkConnect',
+        'Program 2:networkConnect',
+        'Program 2:attemptUseVulnerability',
+        'Program 2:softwareProductVulnerabilityNetworkAccessAchieved',
+        'Program 2:denyFromNetworkingAsset',
+        'Program 1:denyFromNetworkingAsset',
+        'Network:2:adversaryInTheMiddle',
+        'Network:2:eavesdrop',
+        'ConnectionRule:3:accessNetworksInspected',
+        'Program 2:attemptReverseReach',
+        'Program 1:attemptReverseReach',
+        'Program 2:attemptDeny'
     ]
 
     assert defender_actions == [
@@ -565,7 +676,7 @@ def test_bfs_vs_bfs_state_and_reward_expected_value_ttc() -> None:
     assert sim.agent_reward(defender_state) == -19
 
     assert total_reward_attacker == -attacker_failed_steps
-    assert total_reward_defender == -2076.0
+    assert total_reward_defender == -7092.0
 
 
 def test_traininglang_advanced_agents() -> None:
@@ -764,8 +875,6 @@ def test_traininglang_dont_compromise_entrypoints() -> None:
         'ConnectionRule:1:successfulAccessNetworksInspected',
         'ConnectionRule:1:connectToApplicationsInspected',
         'ConnectionRule:1:accessNetworksUninspected',
-        'ConnectionRule:1:restrictedBypassed',
-        'ConnectionRule:1:payloadInspectionBypassed',
         'Program 1:networkConnectUninspected',
         'Program 1:networkConnectInspected',
         'ConnectionRule:1:accessNetworksInspected',
@@ -797,8 +906,6 @@ def test_traininglang_dont_compromise_entrypoints() -> None:
         'ConnectionRule:1:attemptReverseReach',
         'Program 2:networkConnectUninspected',
         'Program 2:networkConnectInspected',
-        'ConnectionRule:3:restrictedBypassed',
-        'ConnectionRule:3:payloadInspectionBypassed',
         'ConnectionRule:3:deny',
         'ConnectionRule:1:deny',
         'Network:2:successfulAdversaryInTheMiddle',
@@ -816,13 +923,11 @@ def test_traininglang_dont_compromise_entrypoints() -> None:
         'Program 2:denyFromNetworkingAsset',
         'Program 1:denyFromNetworkingAsset',
         'Network:2:adversaryInTheMiddle',
-        'Network:2:adversaryInTheMiddleDefenseBypassed',
-        'Network:2:eavesdropDefenseBypassed',
         'Network:2:eavesdrop',
         'ConnectionRule:3:accessNetworksInspected',
         'Program 2:attemptReverseReach',
         'Program 1:attemptReverseReach',
-        'Program 2:attemptDeny',
+        'Program 2:attemptDeny'
     ]
     assert defender_actions == [
         'Network:2:adversaryInTheMiddleDefense',

--- a/tests/envs/test_example_scenarios.py
+++ b/tests/envs/test_example_scenarios.py
@@ -83,8 +83,8 @@ def test_bfs_vs_bfs_state_and_reward_first() -> None:
         total_reward_defender += sim.agent_reward(defender_state)
         total_reward_attacker += sim.agent_reward(attacker_state)
 
-    assert defender_state.iteration == 41
-    assert attacker_state.iteration == 41
+    assert defender_state.iteration == 45
+    assert attacker_state.iteration == 45
 
     # Make sure the actions performed were as expected
     assert attacker_actions == [
@@ -92,7 +92,8 @@ def test_bfs_vs_bfs_state_and_reward_first() -> None:
         'Internet:networkForwardingUninspected',
         'Internet:deny',
         'Internet:accessNetworkData',
-        'ConnectionRule Internet->Linux System:attemptConnectToApplicationsUninspected',
+        'ConnectionRule Internet->Linux '
+        'System:attemptConnectToApplicationsUninspected',
         'Internet:reverseReach',
         'Internet:networkForwardingInspected',
         'ConnectionRule Internet->Linux System:attemptAccessNetworksUninspected',
@@ -111,6 +112,8 @@ def test_bfs_vs_bfs_state_and_reward_first() -> None:
         'Internet:successfulEavesdrop',
         'Internet:bypassAdversaryInTheMiddleDefense',
         'Internet:successfulAdversaryInTheMiddle',
+        'ConnectionRule Internet->Linux System:restrictedBypassed',
+        'ConnectionRule Internet->Linux System:payloadInspectionBypassed',
         'Linux system:networkConnectUninspected',
         'Linux system:networkConnectInspected',
         'ConnectionRule Internet->Linux System:reverseReach',
@@ -118,7 +121,9 @@ def test_bfs_vs_bfs_state_and_reward_first() -> None:
         'ConnectionRule Internet->Linux System:connectToApplicationsInspected',
         'ConnectionRule Internet->Linux System:accessNetworksUninspected',
         'Linux system:denyFromNetworkingAsset',
+        'Internet:eavesdropDefenseBypassed',
         'Internet:eavesdrop',
+        'Internet:adversaryInTheMiddleDefenseBypassed',
         'Internet:adversaryInTheMiddle',
         'Linux system:attemptUseVulnerability',
         'Linux system:networkConnect',
@@ -127,7 +132,7 @@ def test_bfs_vs_bfs_state_and_reward_first() -> None:
         'Linux system:attemptReverseReach',
         'ConnectionRule Internet->Linux System:accessNetworksInspected',
         'Linux system:attemptDeny',
-        'Internet:accessInspected',
+        'Internet:accessInspected'
     ]
 
     assert defender_actions == [
@@ -156,7 +161,7 @@ def test_bfs_vs_bfs_state_and_reward_first() -> None:
     assert sim.agent_reward(defender_state) == -50
 
     assert total_reward_attacker == 0
-    assert total_reward_defender == -2000
+    assert total_reward_defender == -2200
 
 
 def test_bfs_vs_bfs_state_and_reward_per_step_ttc() -> None:
@@ -875,6 +880,8 @@ def test_traininglang_dont_compromise_entrypoints() -> None:
         'ConnectionRule:1:successfulAccessNetworksInspected',
         'ConnectionRule:1:connectToApplicationsInspected',
         'ConnectionRule:1:accessNetworksUninspected',
+        'ConnectionRule:1:restrictedBypassed',
+        'ConnectionRule:1:payloadInspectionBypassed',
         'Program 1:networkConnectUninspected',
         'Program 1:networkConnectInspected',
         'ConnectionRule:1:accessNetworksInspected',
@@ -906,6 +913,8 @@ def test_traininglang_dont_compromise_entrypoints() -> None:
         'ConnectionRule:1:attemptReverseReach',
         'Program 2:networkConnectUninspected',
         'Program 2:networkConnectInspected',
+        'ConnectionRule:3:restrictedBypassed',
+        'ConnectionRule:3:payloadInspectionBypassed',
         'ConnectionRule:3:deny',
         'ConnectionRule:1:deny',
         'Network:2:successfulAdversaryInTheMiddle',
@@ -923,11 +932,13 @@ def test_traininglang_dont_compromise_entrypoints() -> None:
         'Program 2:denyFromNetworkingAsset',
         'Program 1:denyFromNetworkingAsset',
         'Network:2:adversaryInTheMiddle',
+        'Network:2:adversaryInTheMiddleDefenseBypassed',
+        'Network:2:eavesdropDefenseBypassed',
         'Network:2:eavesdrop',
         'ConnectionRule:3:accessNetworksInspected',
         'Program 2:attemptReverseReach',
         'Program 1:attemptReverseReach',
-        'Program 2:attemptDeny',
+        'Program 2:attemptDeny'
     ]
     assert defender_actions == [
         'Network:2:adversaryInTheMiddleDefense',

--- a/tests/envs/test_example_scenarios.py
+++ b/tests/envs/test_example_scenarios.py
@@ -92,8 +92,7 @@ def test_bfs_vs_bfs_state_and_reward_first() -> None:
         'Internet:networkForwardingUninspected',
         'Internet:deny',
         'Internet:accessNetworkData',
-        'ConnectionRule Internet->Linux '
-        'System:attemptConnectToApplicationsUninspected',
+        'ConnectionRule Internet->Linux System:attemptConnectToApplicationsUninspected',
         'Internet:reverseReach',
         'Internet:networkForwardingInspected',
         'ConnectionRule Internet->Linux System:attemptAccessNetworksUninspected',
@@ -132,7 +131,7 @@ def test_bfs_vs_bfs_state_and_reward_first() -> None:
         'Linux system:attemptReverseReach',
         'ConnectionRule Internet->Linux System:accessNetworksInspected',
         'Linux system:attemptDeny',
-        'Internet:accessInspected'
+        'Internet:accessInspected',
     ]
 
     assert defender_actions == [
@@ -938,7 +937,7 @@ def test_traininglang_dont_compromise_entrypoints() -> None:
         'ConnectionRule:3:accessNetworksInspected',
         'Program 2:attemptReverseReach',
         'Program 1:attemptReverseReach',
-        'Program 2:attemptDeny'
+        'Program 2:attemptDeny',
     ]
     assert defender_actions == [
         'Network:2:adversaryInTheMiddleDefense',

--- a/tests/envs/test_example_scenarios.py
+++ b/tests/envs/test_example_scenarios.py
@@ -303,7 +303,7 @@ def test_bfs_vs_bfs_state_and_reward_per_step_ttc() -> None:
         'ConnectionRule:3:accessNetworksInspected',
         'Program 2:attemptReverseReach',
         'Program 1:attemptReverseReach',
-        'Program 2:attemptDeny'
+        'Program 2:attemptDeny',
     ]
 
     assert defender_actions == [
@@ -472,7 +472,7 @@ def test_bfs_vs_bfs_state_and_reward_per_step_effort_based() -> None:
         'ConnectionRule:3:accessNetworksInspected',
         'Program 2:attemptReverseReach',
         'Program 1:attemptReverseReach',
-        'Program 2:attemptDeny'
+        'Program 2:attemptDeny',
     ]
 
     assert defender_actions == [
@@ -644,7 +644,7 @@ def test_bfs_vs_bfs_state_and_reward_expected_value_ttc() -> None:
         'ConnectionRule:3:accessNetworksInspected',
         'Program 2:attemptReverseReach',
         'Program 1:attemptReverseReach',
-        'Program 2:attemptDeny'
+        'Program 2:attemptDeny',
     ]
 
     assert defender_actions == [
@@ -927,7 +927,7 @@ def test_traininglang_dont_compromise_entrypoints() -> None:
         'ConnectionRule:3:accessNetworksInspected',
         'Program 2:attemptReverseReach',
         'Program 1:attemptReverseReach',
-        'Program 2:attemptDeny'
+        'Program 2:attemptDeny',
     ]
     assert defender_actions == [
         'Network:2:adversaryInTheMiddleDefense',

--- a/tests/envs/test_example_scenarios.py
+++ b/tests/envs/test_example_scenarios.py
@@ -244,41 +244,67 @@ def test_bfs_vs_bfs_state_and_reward_per_step_ttc() -> None:
         'ConnectionRule:1:attemptConnectToApplicationsUninspected',
         'ConnectionRule:1:attemptAccessNetworksInspected',
         'ConnectionRule:1:attemptConnectToApplicationsInspected',
+        'Program 1:bypassContainerization',
+        'ConnectionRule:1:successfulAccessNetworksUninspected',
         'ConnectionRule:1:bypassRestricted',
+        'ConnectionRule:1:bypassPayloadInspection',
+        'ConnectionRule:1:connectToApplicationsUninspected',
         'ConnectionRule:1:successfulAccessNetworksInspected',
         'ConnectionRule:1:connectToApplicationsInspected',
-        'ConnectionRule:1:accessNetworksInspected',
+        'ConnectionRule:1:accessNetworksUninspected',
+        'Program 1:networkConnectUninspected',
         'Program 1:networkConnectInspected',
-        'Network:2:accessInspected',
-        'Program 1:specificAccessNetworkConnect',
+        'ConnectionRule:1:accessNetworksInspected',
+        'Network:2:accessUninspected',
+        'Program 1:softwareProductVulnerabilityNetworkAccessAchieved',
         'Program 1:networkConnect',
+        'Program 1:specificAccessNetworkConnect',
+        'Program 1:attemptUseVulnerability',
+        'Network:2:accessInspected',
         'Network:2:accessNetworkData',
-        'Network:2:networkForwardingInspected',
+        'Network:2:attemptReverseReach',
+        'ConnectionRule:3:attemptConnectToApplicationsUninspected',
+        'Network:2:networkForwardingUninspected',
         'Network:2:deny',
+        'Network:2:networkForwardingInspected',
         'ConnectionRule:3:attemptConnectToApplicationsInspected',
-        'Network:2:attemptEavesdrop',
         'Network:2:attemptAdversaryInTheMiddle',
-        'ConnectionRule:3:attemptAccessNetworksInspected',
-        'ConnectionRule:1:attemptDeny',
-        'ConnectionRule:3:attemptDeny',
+        'Network:2:attemptEavesdrop',
+        'Network:2:reverseReach',
         'ConnectionRule:3:bypassPayloadInspection',
+        'ConnectionRule:3:connectToApplicationsUninspected',
         'ConnectionRule:3:bypassRestricted',
+        'ConnectionRule:3:attemptAccessNetworksUninspected',
+        'ConnectionRule:3:attemptDeny',
+        'ConnectionRule:1:attemptDeny',
+        'ConnectionRule:3:attemptAccessNetworksInspected',
         'ConnectionRule:3:connectToApplicationsInspected',
-        'Network:2:successfulEavesdrop',
-        'Network:2:bypassEavesdropDefense',
         'Network:2:bypassAdversaryInTheMiddleDefense',
         'Network:2:successfulAdversaryInTheMiddle',
-        'ConnectionRule:3:successfulAccessNetworksInspected',
-        'ConnectionRule:1:deny',
-        'ConnectionRule:3:deny',
+        'Network:2:successfulEavesdrop',
+        'Network:2:bypassEavesdropDefense',
+        'ConnectionRule:1:attemptReverseReach',
+        'ConnectionRule:3:attemptReverseReach',
         'Program 2:networkConnectInspected',
-        'Network:2:eavesdrop',
+        'Program 2:networkConnectUninspected',
+        'ConnectionRule:3:successfulAccessNetworksUninspected',
+        'ConnectionRule:3:deny',
+        'ConnectionRule:1:deny',
+        'ConnectionRule:3:successfulAccessNetworksInspected',
         'Network:2:adversaryInTheMiddle',
-        'ConnectionRule:3:accessNetworksInspected',
-        'Program 1:denyFromNetworkingAsset',
-        'Program 2:denyFromNetworkingAsset',
+        'Network:2:eavesdrop',
+        'ConnectionRule:1:reverseReach',
+        'ConnectionRule:3:reverseReach',
         'Program 2:specificAccessNetworkConnect',
         'Program 2:networkConnect',
+        'Program 2:attemptUseVulnerability',
+        'Program 2:softwareProductVulnerabilityNetworkAccessAchieved',
+        'ConnectionRule:3:accessNetworksUninspected',
+        'Program 2:denyFromNetworkingAsset',
+        'Program 1:denyFromNetworkingAsset',
+        'ConnectionRule:3:accessNetworksInspected',
+        'Program 1:attemptReverseReach',
+        'Program 2:attemptReverseReach',
         'Program 2:attemptDeny',
     ]
 
@@ -311,7 +337,7 @@ def test_bfs_vs_bfs_state_and_reward_per_step_ttc() -> None:
     assert sim.agent_reward(defender_state) == -19
 
     assert total_reward_attacker == -attacker_failed_steps
-    assert total_reward_defender == -15927.0
+    assert total_reward_defender == -17143.0
 
 
 def test_bfs_vs_bfs_state_and_reward_per_step_effort_based() -> None:
@@ -372,8 +398,8 @@ def test_bfs_vs_bfs_state_and_reward_per_step_effort_based() -> None:
         total_reward_defender += sim.agent_reward(defender_state)
         total_reward_attacker += sim.agent_reward(attacker_state)
 
-    assert attacker_state.iteration == 12
-    assert defender_state.iteration == 12
+    assert attacker_state.iteration == 37
+    assert defender_state.iteration == 37
 
     # Make sure the actions performed were as expected
     assert attacker_actions == [
@@ -386,6 +412,14 @@ def test_bfs_vs_bfs_state_and_reward_per_step_effort_based() -> None:
         'ConnectionRule:1:attemptAccessNetworksUninspected',
         'ConnectionRule:1:attemptConnectToApplicationsUninspected',
         'ConnectionRule:1:attemptAccessNetworksInspected',
+        # Below steps are because of persistance
+        'ConnectionRule:1:attemptConnectToApplicationsInspected',
+        'Program 1:bypassContainerization',
+        'ConnectionRule:1:bypassRestricted',
+        'ConnectionRule:1:connectToApplicationsInspected',
+        'Program 1:networkConnectInspected',
+        'Program 1:networkConnect',
+        'Program 1:specificAccessNetworkConnect',
     ]
 
     assert defender_actions == [
@@ -417,7 +451,7 @@ def test_bfs_vs_bfs_state_and_reward_per_step_effort_based() -> None:
     assert sim.agent_reward(defender_state) == -19
 
     assert total_reward_attacker == -attacker_failed_steps
-    assert total_reward_defender == -100.0
+    assert total_reward_defender == -575.0
 
 
 def test_bfs_vs_bfs_state_and_reward_expected_value_ttc() -> None:
@@ -480,8 +514,8 @@ def test_bfs_vs_bfs_state_and_reward_expected_value_ttc() -> None:
         total_reward_defender += sim.agent_reward(defender_state)
         total_reward_attacker += sim.agent_reward(attacker_state)
 
-    assert attacker_state.iteration == 12
-    assert defender_state.iteration == 12
+    assert attacker_state.iteration == 116
+    assert defender_state.iteration == 116
 
     # Make sure the actions performed were as expected
     assert attacker_actions == [
@@ -494,6 +528,12 @@ def test_bfs_vs_bfs_state_and_reward_expected_value_ttc() -> None:
         'ConnectionRule:1:attemptAccessNetworksUninspected',
         'ConnectionRule:1:attemptConnectToApplicationsUninspected',
         'ConnectionRule:1:attemptAccessNetworksInspected',
+        'ConnectionRule:1:attemptConnectToApplicationsInspected',
+        'ConnectionRule:1:bypassRestricted',
+        'ConnectionRule:1:connectToApplicationsInspected',
+        'Program 1:networkConnectInspected',
+        'Program 1:networkConnect',
+        'Program 1:specificAccessNetworkConnect',
     ]
 
     assert defender_actions == [
@@ -525,7 +565,7 @@ def test_bfs_vs_bfs_state_and_reward_expected_value_ttc() -> None:
     assert sim.agent_reward(defender_state) == -19
 
     assert total_reward_attacker == -attacker_failed_steps
-    assert total_reward_defender == -100.0
+    assert total_reward_defender == -2076.0
 
 
 def test_traininglang_advanced_agents() -> None:
@@ -706,76 +746,82 @@ def test_traininglang_dont_compromise_entrypoints() -> None:
         'Program 1:attemptDeny',
         'Program 1:accessNetworkAndConnections',
         'Program 1:attemptModify',
+        'Program 1:specificAccess',
         'ConnectionRule:1:attemptAccessNetworksUninspected',
         'ConnectionRule:1:attemptConnectToApplicationsUninspected',
         'ConnectionRule:1:attemptAccessNetworksInspected',
         'ConnectionRule:1:attemptConnectToApplicationsInspected',
-        'ConnectionRule:1:bypassRestricted',
+        'Program 1:attemptAuthorizedApplicationRespondConnectThroughData',
+        'Program 1:specificAccessModify',
+        'Program 1:attemptUseVulnerability',
+        'Program 1:bypassContainerization',
+        'Program 1:specificAccessRead',
+        'Program 1:specificAccessDelete',
         'ConnectionRule:1:successfulAccessNetworksUninspected',
-        'ConnectionRule:1:connectToApplicationsUninspected',
+        'ConnectionRule:1:bypassRestricted',
         'ConnectionRule:1:bypassPayloadInspection',
+        'ConnectionRule:1:connectToApplicationsUninspected',
         'ConnectionRule:1:successfulAccessNetworksInspected',
         'ConnectionRule:1:connectToApplicationsInspected',
-        'ConnectionRule:1:restrictedBypassed',
         'ConnectionRule:1:accessNetworksUninspected',
-        'Program 1:networkConnectInspected',
-        'Program 1:networkConnectUninspected',
+        'ConnectionRule:1:restrictedBypassed',
         'ConnectionRule:1:payloadInspectionBypassed',
+        'Program 1:networkConnectUninspected',
+        'Program 1:networkConnectInspected',
         'ConnectionRule:1:accessNetworksInspected',
         'Network:2:accessUninspected',
-        'Program 1:networkConnect',
         'Program 1:specificAccessNetworkConnect',
+        'Program 1:networkConnect',
         'Program 1:softwareProductVulnerabilityNetworkAccessAchieved',
-        'Program 1:attemptUseVulnerability',
         'Network:2:accessInspected',
         'Network:2:networkForwardingUninspected',
         'Network:2:attemptReverseReach',
-        'Network:2:deny',
         'ConnectionRule:3:attemptConnectToApplicationsUninspected',
+        'Network:2:deny',
         'Network:2:accessNetworkData',
-        'Network:2:networkForwardingInspected',
         'ConnectionRule:3:attemptConnectToApplicationsInspected',
+        'Network:2:networkForwardingInspected',
         'ConnectionRule:3:attemptAccessNetworksUninspected',
         'Network:2:reverseReach',
-        'ConnectionRule:1:attemptDeny',
-        'ConnectionRule:3:attemptDeny',
-        'ConnectionRule:3:bypassPayloadInspection',
-        'ConnectionRule:3:bypassRestricted',
         'ConnectionRule:3:connectToApplicationsUninspected',
+        'ConnectionRule:3:bypassRestricted',
+        'ConnectionRule:3:bypassPayloadInspection',
+        'ConnectionRule:3:attemptDeny',
+        'ConnectionRule:1:attemptDeny',
         'Network:2:attemptAdversaryInTheMiddle',
         'Network:2:attemptEavesdrop',
-        'ConnectionRule:3:attemptAccessNetworksInspected',
         'ConnectionRule:3:connectToApplicationsInspected',
+        'ConnectionRule:3:attemptAccessNetworksInspected',
         'ConnectionRule:3:successfulAccessNetworksUninspected',
-        'ConnectionRule:1:attemptReverseReach',
         'ConnectionRule:3:attemptReverseReach',
-        'ConnectionRule:1:deny',
-        'ConnectionRule:3:deny',
-        'ConnectionRule:3:payloadInspectionBypassed',
-        'ConnectionRule:3:restrictedBypassed',
-        'Program 2:networkConnectInspected',
+        'ConnectionRule:1:attemptReverseReach',
         'Program 2:networkConnectUninspected',
+        'Program 2:networkConnectInspected',
+        'ConnectionRule:3:restrictedBypassed',
+        'ConnectionRule:3:payloadInspectionBypassed',
+        'ConnectionRule:3:deny',
+        'ConnectionRule:1:deny',
         'Network:2:successfulAdversaryInTheMiddle',
         'Network:2:bypassAdversaryInTheMiddleDefense',
-        'Network:2:successfulEavesdrop',
         'Network:2:bypassEavesdropDefense',
+        'Network:2:successfulEavesdrop',
         'ConnectionRule:3:successfulAccessNetworksInspected',
         'ConnectionRule:3:accessNetworksUninspected',
-        'ConnectionRule:1:reverseReach',
         'ConnectionRule:3:reverseReach',
-        'Program 1:denyFromNetworkingAsset',
-        'Program 2:denyFromNetworkingAsset',
-        'Program 2:specificAccessNetworkConnect',
+        'ConnectionRule:1:reverseReach',
         'Program 2:networkConnect',
-        'Program 2:attemptUseVulnerability',
         'Program 2:softwareProductVulnerabilityNetworkAccessAchieved',
+        'Program 2:specificAccessNetworkConnect',
+        'Program 2:attemptUseVulnerability',
+        'Program 2:denyFromNetworkingAsset',
+        'Program 1:denyFromNetworkingAsset',
         'Network:2:adversaryInTheMiddle',
         'Network:2:adversaryInTheMiddleDefenseBypassed',
-        'Network:2:eavesdrop',
         'Network:2:eavesdropDefenseBypassed',
+        'Network:2:eavesdrop',
         'ConnectionRule:3:accessNetworksInspected',
-        'Program 1:attemptReverseReach',
         'Program 2:attemptReverseReach',
+        'Program 1:attemptReverseReach',
         'Program 2:attemptDeny',
     ]
     assert defender_actions == [

--- a/tests/envs/test_graph_env.py
+++ b/tests/envs/test_graph_env.py
@@ -56,9 +56,7 @@ from malsim.envs.graph.wrapper import ActionThenAssetWrapper, AssetThenActionWra
             ttc_mode=TTCMode.DISABLED,
             run_defense_step_bernoullis=False,
             run_attack_step_bernoullis=False,
-            attack_surface=AttackSurfaceSettings(
-                skip_unnecessary=False, skip_unviable=False
-            ),
+            attack_surface=AttackSurfaceSettings(skip_unnecessary=False),
         ),
     ],
 )

--- a/tests/envs/test_vectorized_obs_mal_simulator.py
+++ b/tests/envs/test_vectorized_obs_mal_simulator.py
@@ -486,14 +486,15 @@ def test_malsimulator_observe_and_reward_attacker_defender() -> None:
     assert rew[defender_agent_name] == -rew[attacker_name]
 
     # Step defender and attacker
-    # Attacker wont be able to traverse Data:2:read since
-    # Host:0:notPresent is activated before
+    # Attacker will be able to traverse Data:2:read since
+    # attack steps are persistent
     obs, rew, _, _, _ = env.step(
         {
             defender_agent_name: (1, env.node_to_index(host_0_notPresent)),
             attacker_name: (1, env.node_to_index(data_2_read)),
         }
     )
+    attacker_reached_steps.append(data_2_read.id)
     defender_enabled_steps.append(host_0_notPresent.id)
 
     # Attacker obs state should look the same as before
@@ -507,9 +508,10 @@ def test_malsimulator_observe_and_reward_attacker_defender() -> None:
         attacker_reached_steps + defender_enabled_steps,
     )
 
+    rew_data_2_read = 5
     # Verify rewards
     reward_host_0_not_present = 2
-    assert rew[attacker_name] == reward_host_0_access  # no additional reward
+    assert rew[attacker_name] == reward_host_0_access + rew_data_2_read
     assert rew[defender_agent_name] == -rew[attacker_name] - reward_host_0_not_present
 
 

--- a/tests/test_attacker.py
+++ b/tests/test_attacker.py
@@ -2,7 +2,7 @@ from collections.abc import Set
 
 from maltoolbox.attackgraph import AttackGraphNode
 
-from malsim.config.sim_settings import MalSimulatorSettings
+from malsim.config.sim_settings import AttackSurfaceSettings, MalSimulatorSettings
 from malsim.mal_simulator.attack_surface import get_attack_surface
 from malsim.mal_simulator.simulator import MalSimulator
 from malsim.scenario.scenario import Scenario
@@ -48,25 +48,67 @@ def test_attack_surface_traininglang() -> None:
 
 
 def _validate_attack_surface(
-    sim: MalSimulator, attack_surface: Set[AttackGraphNode]
+    sim: MalSimulator,
+    attack_surface: Set[AttackGraphNode],
+    performed_nodes: Set[AttackGraphNode],
 ) -> None:
+    def _parent_is_blocking_defense(node: AttackGraphNode) -> bool:
+        if node.type == 'and':
+            return any(
+                sim.node_is_enabled_defense(parent_node) for parent_node in node.parents
+            )
+        elif node.type == 'or':
+            return all(
+                sim.node_is_enabled_defense(parent_node) for parent_node in node.parents
+            )
+        else:
+            return False
+
+    def _parent_is_blocking_exists(node: AttackGraphNode) -> bool:
+        if node.type == 'and':
+            return any(
+                parent.existence_status
+                if parent.existence_status is not None
+                else False
+                for parent in node.parents
+                if parent.type == 'exist'
+            )
+        elif node.type == 'or':
+            return all(
+                parent.existence_status
+                if parent.existence_status is not None
+                else False
+                for parent in node.parents
+                if parent.type == 'exist'
+            )
+        else:
+            return False
+
+    def _parent_is_blocking_not_exists(node: AttackGraphNode) -> bool:
+        if node.type == 'and':
+            return all(
+                parent.existence_status
+                if parent.existence_status is not None
+                else False
+                for parent in node.parents
+                if parent.type == 'notExist'
+            )
+        elif node.type == 'or':
+            return any(
+                parent.existence_status
+                if parent.existence_status is not None
+                else False
+                for parent in node.parents
+                if parent.type == 'notExist'
+            )
+        else:
+            return False
+
     for node in attack_surface:
-        one_parent_is_enabled_defense = any(
-            sim.node_is_enabled_defense(parent_node) for parent_node in node.parents
+        assert not _parent_is_blocking_defense(node), (
+            f'Attack surface node {node} is blocked by defense, '
+            'but is in the attack surface.'
         )
-        assert not one_parent_is_enabled_defense or node.type == 'or', (
-            f'Attack surface node {node} has an enabled defense parent,'
-            ' which should not be the case.'
-        )
-
-        all_parent_is_enabled_defense = all(
-            sim.node_is_enabled_defense(parent_node) for parent_node in node.parents
-        )
-        assert not all_parent_is_enabled_defense, (
-            f'Attack surface node {node} has all enabled defense parents,'
-            ' which should not be the case.'
-        )
-
         parent_is_compromised = any(
             sim.node_is_compromised(parent_node) for parent_node in node.parents
         )
@@ -75,27 +117,48 @@ def _validate_attack_surface(
             ' which should not be the case.'
         )
 
+    for node in performed_nodes:
+        # Go through all nodes that could be in attack surface and find out why not
+        assert node not in attack_surface, (
+            f'Performed node {node} is in attack surface, which should not be the case.'
+        )
+
+        for child in node.children:
+            if not (
+                child in performed_nodes
+                or (_parent_is_blocking_defense(child))
+                or (_parent_is_blocking_exists(child))
+                or (_parent_is_blocking_not_exists(child))
+                or (child in sim.sim_state.graph_state.impossible_attack_steps)
+            ):
+                assert child in attack_surface, (
+                    f'Child node {child} of performed node {node} is not in '
+                    'attack surface, but should be. It is not blocked by defense '
+                    ' and all parents are compromised.'
+                )
+
 
 def test_attack_surface_coreLang() -> None:
     scenario_file = 'tests/testdata/scenarios/simple_scenario.yml'
     scenario = Scenario.load_from_file(
-        scenario_file, sim_settings=MalSimulatorSettings(seed=42)
+        scenario_file,
+        sim_settings=MalSimulatorSettings(
+            seed=42, attack_surface=AttackSurfaceSettings(skip_unnecessary=False)
+        ),
     )
     sim = MalSimulator.from_scenario(scenario)
 
     while True:
-        attack_surface = get_attack_surface(
-            sim.sim_settings.attack_surface,
-            sim.sim_state,
-            sim.agent_states['Attacker1'].settings.actionable_steps,
+        next_choice = next(
+            (node for node in sim.agent_states['Attacker1'].action_surface), None
+        )
+        sim.step({'Attacker1': [next_choice] if next_choice else []})
+        _validate_attack_surface(
+            sim,
+            sim.agent_states['Attacker1'].action_surface,
             sim.agent_states['Attacker1'].performed_nodes,
         )
-        _validate_attack_surface(sim, attack_surface)
-
-        next_choice = next((node for node in attack_surface), None)
-        sim.step({'Attacker1': [next_choice] if next_choice else []})
-
         if sim.agent_is_terminated('Attacker1'):
             break
 
-    assert sim.agent_states['Attacker1'].iteration == 98
+    assert sim.agent_states['Attacker1'].iteration == 99

--- a/tests/test_attacker.py
+++ b/tests/test_attacker.py
@@ -1,0 +1,42 @@
+from malsim.mal_simulator.attack_surface import get_attack_surface
+from malsim.mal_simulator.attacker_state import AttackerState
+from malsim.mal_simulator.defense_surface import get_defense_surface
+from malsim.mal_simulator.simulator import MalSimulator
+
+
+def test_attack_surface():
+    """
+    Run defender to block attack surface and check that attack surface is updated accordingly.
+    """
+
+    scenario = 'tests/testdata/scenarios/traininglang_scenario.yml'
+    sim = MalSimulator.from_scenario(scenario)
+
+    attack_surface = get_attack_surface(
+        sim.sim_settings.attack_surface,
+        sim.sim_state,
+        sim.agent_states['Attacker1'].settings.actionable_steps,
+        sim.agent_states['Attacker1'].performed_nodes,
+    )
+    assert attack_surface == {sim.get_node('User:3:compromise')}
+
+    # This wont help, already compromised
+    sim.step({'Defender1': [sim.get_node('Host:0:notPresent')]})
+    attack_surface = get_attack_surface(
+        sim.sim_settings.attack_surface,
+        sim.sim_state,
+        sim.agent_states['Attacker1'].settings.actionable_steps,
+        sim.agent_states['Attacker1'].performed_nodes,
+    )
+    assert attack_surface == {sim.get_node('User:3:compromise')}
+
+    # This should block the attack from further propagating
+    sim.step({'Defender1': [sim.get_node('User:3:notPresent')]})
+    attack_surface = get_attack_surface(
+        sim.sim_settings.attack_surface,
+        sim.sim_state,
+        sim.agent_states['Attacker1'].settings.actionable_steps,
+        sim.agent_states['Attacker1'].performed_nodes,
+    )
+    assert attack_surface == set()
+    assert sim.agent_is_terminated('Attacker1')

--- a/tests/test_attacker.py
+++ b/tests/test_attacker.py
@@ -8,7 +8,7 @@ from malsim.mal_simulator.simulator import MalSimulator
 from malsim.scenario.scenario import Scenario
 
 
-def test_attack_surface_traininglang():
+def test_attack_surface_traininglang() -> None:
     """
     Run defender to block attack surface and check
     that attack surface is updated accordingly.
@@ -47,7 +47,9 @@ def test_attack_surface_traininglang():
     assert sim.agent_is_terminated('Attacker1')
 
 
-def _validate_attack_surface(sim: MalSimulator, attack_surface: Set[AttackGraphNode]):
+def _validate_attack_surface(
+    sim: MalSimulator, attack_surface: Set[AttackGraphNode]
+) -> None:
     for node in attack_surface:
         one_parent_is_enabled_defense = any(
             sim.node_is_enabled_defense(parent_node) for parent_node in node.parents
@@ -74,10 +76,10 @@ def _validate_attack_surface(sim: MalSimulator, attack_surface: Set[AttackGraphN
         )
 
 
-def test_attack_surface_coreLang():
-    scenario = 'tests/testdata/scenarios/simple_scenario.yml'
+def test_attack_surface_coreLang() -> None:
+    scenario_file = 'tests/testdata/scenarios/simple_scenario.yml'
     scenario = Scenario.load_from_file(
-        scenario, sim_settings=MalSimulatorSettings(seed=42)
+        scenario_file, sim_settings=MalSimulatorSettings(seed=42)
     )
     sim = MalSimulator.from_scenario(scenario)
 

--- a/tests/test_attacker.py
+++ b/tests/test_attacker.py
@@ -1,12 +1,17 @@
+from collections.abc import Set
+
+from maltoolbox.attackgraph import AttackGraphNode
+
+from malsim.config.sim_settings import MalSimulatorSettings
 from malsim.mal_simulator.attack_surface import get_attack_surface
-from malsim.mal_simulator.attacker_state import AttackerState
-from malsim.mal_simulator.defense_surface import get_defense_surface
 from malsim.mal_simulator.simulator import MalSimulator
+from malsim.scenario.scenario import Scenario
 
 
-def test_attack_surface():
+def test_attack_surface_traininglang():
     """
-    Run defender to block attack surface and check that attack surface is updated accordingly.
+    Run defender to block attack surface and check
+    that attack surface is updated accordingly.
     """
 
     scenario = 'tests/testdata/scenarios/traininglang_scenario.yml'
@@ -40,3 +45,55 @@ def test_attack_surface():
     )
     assert attack_surface == set()
     assert sim.agent_is_terminated('Attacker1')
+
+
+def _validate_attack_surface(sim: MalSimulator, attack_surface: Set[AttackGraphNode]):
+    for node in attack_surface:
+        one_parent_is_enabled_defense = any(
+            sim.node_is_enabled_defense(parent_node) for parent_node in node.parents
+        )
+        assert not one_parent_is_enabled_defense or node.type == 'or', (
+            f'Attack surface node {node} has an enabled defense parent,'
+            ' which should not be the case.'
+        )
+
+        all_parent_is_enabled_defense = all(
+            sim.node_is_enabled_defense(parent_node) for parent_node in node.parents
+        )
+        assert not all_parent_is_enabled_defense, (
+            f'Attack surface node {node} has all enabled defense parents,'
+            ' which should not be the case.'
+        )
+
+        parent_is_compromised = any(
+            sim.node_is_compromised(parent_node) for parent_node in node.parents
+        )
+        assert parent_is_compromised, (
+            f'Attack surface node {node} has a parent that is not compromised,'
+            ' which should not be the case.'
+        )
+
+
+def test_attack_surface_coreLang():
+    scenario = 'tests/testdata/scenarios/simple_scenario.yml'
+    scenario = Scenario.load_from_file(
+        scenario, sim_settings=MalSimulatorSettings(seed=42)
+    )
+    sim = MalSimulator.from_scenario(scenario)
+
+    while True:
+        attack_surface = get_attack_surface(
+            sim.sim_settings.attack_surface,
+            sim.sim_state,
+            sim.agent_states['Attacker1'].settings.actionable_steps,
+            sim.agent_states['Attacker1'].performed_nodes,
+        )
+        _validate_attack_surface(sim, attack_surface)
+
+        next_choice = next((node for node in attack_surface), None)
+        sim.step({'Attacker1': [next_choice] if next_choice else []})
+
+        if sim.agent_is_terminated('Attacker1'):
+            break
+
+    assert sim.agent_states['Attacker1'].iteration == 98

--- a/tests/test_defender.py
+++ b/tests/test_defender.py
@@ -1,4 +1,3 @@
-from malsim.mal_simulator.defense_surface import get_defense_surface
 from malsim.mal_simulator.simulator import MalSimulator
 
 
@@ -16,15 +15,22 @@ def test_defense_surface() -> None:
         sim.get_node('Data:2:notPresent'),
         sim.get_node('User:3:notPresent'),
     }
-    defense_surface = get_defense_surface(
-        sim.sim_state,
-        sim.agent_states['Defender1'].settings.actionable_steps,
-    )
-    assert defense_surface == expected_defense_surface
+    assert sim.agent_states['Defender1'].action_surface == expected_defense_surface
 
-    # TODO: should defender action surface shrink when nodes are performed?
+    expected_defense_surface = {
+        sim.get_node('Host:1:notPresent'),
+        sim.get_node('Data:2:notPresent'),
+        sim.get_node('User:3:notPresent'),
+    }
     sim.step({'Defender1': [sim.get_node('Host:0:notPresent')]})
-    assert defense_surface == expected_defense_surface
+    assert sim.agent_states['Defender1'].action_surface == expected_defense_surface
+    assert sim.get_node('Host:0:notPresent') in sim.sim_state.enabled_defenses
 
+    expected_defense_surface = {
+        sim.get_node('Host:1:notPresent'),
+        sim.get_node('Data:2:notPresent'),
+    }
     sim.step({'Defender1': [sim.get_node('User:3:notPresent')]})
-    assert defense_surface == expected_defense_surface
+    assert sim.agent_states['Defender1'].action_surface == expected_defense_surface
+    assert sim.get_node('Host:0:notPresent') in sim.sim_state.enabled_defenses
+    assert sim.get_node('User:3:notPresent') in sim.sim_state.enabled_defenses

--- a/tests/test_defender.py
+++ b/tests/test_defender.py
@@ -1,0 +1,39 @@
+from malsim.mal_simulator.attack_surface import get_attack_surface
+from malsim.mal_simulator.attacker_state import AttackerState
+from malsim.mal_simulator.defense_surface import get_defense_surface
+from malsim.mal_simulator.simulator import MalSimulator
+
+
+def test_defense_surface():
+    """
+    Run defender to block attack surface and check that attack surface is updated accordingly.
+    """
+
+    scenario = 'tests/testdata/scenarios/traininglang_scenario.yml'
+    sim = MalSimulator.from_scenario(scenario)
+
+    attack_surface = get_attack_surface(
+        sim.sim_settings.attack_surface,
+        sim.sim_state,
+        sim.agent_states['Attacker1'].settings.actionable_steps,
+        sim.agent_states['Attacker1'].performed_nodes,
+    )
+
+    expected_defense_surface = {
+        sim.get_node('Host:0:notPresent'),
+        sim.get_node('Host:1:notPresent'),
+        sim.get_node('Data:2:notPresent'),
+        sim.get_node('User:3:notPresent'),
+    }
+    defense_surface = get_defense_surface(
+        sim.sim_state,
+        sim.agent_states['Defender1'].settings.actionable_steps,
+    )
+    assert defense_surface == expected_defense_surface
+
+    # TODO: should defender action surface shrink when nodes are performed?
+    sim.step({'Defender1': [sim.get_node('Host:0:notPresent')]})
+    assert defense_surface == expected_defense_surface
+
+    sim.step({'Defender1': [sim.get_node('User:3:notPresent')]})
+    assert defense_surface == expected_defense_surface

--- a/tests/test_defender.py
+++ b/tests/test_defender.py
@@ -1,23 +1,14 @@
-from malsim.mal_simulator.attack_surface import get_attack_surface
-from malsim.mal_simulator.attacker_state import AttackerState
 from malsim.mal_simulator.defense_surface import get_defense_surface
 from malsim.mal_simulator.simulator import MalSimulator
 
 
 def test_defense_surface():
     """
-    Run defender to block attack surface and check that attack surface is updated accordingly.
+    Run defender and check that defense surface is updated accordingly.
     """
 
     scenario = 'tests/testdata/scenarios/traininglang_scenario.yml'
     sim = MalSimulator.from_scenario(scenario)
-
-    attack_surface = get_attack_surface(
-        sim.sim_settings.attack_surface,
-        sim.sim_state,
-        sim.agent_states['Attacker1'].settings.actionable_steps,
-        sim.agent_states['Attacker1'].performed_nodes,
-    )
 
     expected_defense_surface = {
         sim.get_node('Host:0:notPresent'),

--- a/tests/test_defender.py
+++ b/tests/test_defender.py
@@ -2,7 +2,7 @@ from malsim.mal_simulator.defense_surface import get_defense_surface
 from malsim.mal_simulator.simulator import MalSimulator
 
 
-def test_defense_surface():
+def test_defense_surface() -> None:
     """
     Run defender and check that defense surface is updated accordingly.
     """

--- a/tests/test_graph_processing.py
+++ b/tests/test_graph_processing.py
@@ -2,6 +2,7 @@
 
 from collections.abc import MutableSet, Set
 
+from malsim.config.sim_settings import MalSimulatorSettings
 from malsim.mal_simulator.graph_processing import (
     _propagate_viability_from_node,
     _propagate_necessity_from_node,
@@ -12,6 +13,10 @@ from malsim.mal_simulator.graph_processing import (
 from maltoolbox.language import LanguageGraph
 from maltoolbox.attackgraph import AttackGraph, AttackGraphNode
 from maltoolbox.model import Model
+
+from malsim.mal_simulator.graph_state import GraphState
+from malsim.mal_simulator.graph_utils import node_is_blocked
+from malsim.mal_simulator.simulator_state import MalSimulatorState
 
 # Tests
 
@@ -352,3 +357,74 @@ def test_analyzers_apriori_propagate_necessity(dummy_lang_graph: LanguageGraph) 
 
     for node in [unp1, unp2, or_1unp, and_2unp]:
         assert not mutable_necessity_per_node[node]
+
+
+def test_node_is_blocked(dummy_lang_graph: LanguageGraph) -> None:
+    """Make sure nodes defended by parents are blocked"""
+
+    impossible_attack_steps = set()
+    attack_graph = AttackGraph(dummy_lang_graph)
+    dummy_attack_steps = dummy_lang_graph.assets['DummyAsset'].attack_steps
+
+    # Prepare types
+    exist_attack_step_type = dummy_attack_steps['DummyExistAttackStep']
+    not_exist_attack_step_type = dummy_attack_steps['DummyNotExistAttackStep']
+    defense_step_type = dummy_attack_steps['DummyDefenseAttackStep']
+    and_attack_step_type = dummy_attack_steps['DummyAndAttackStep']
+    or_attack_step_type = dummy_attack_steps['DummyOrAttackStep']
+
+    # exists, existance_status = False -> blocks child
+    exist_node = attack_graph.add_node(exist_attack_step_type)
+    exist_node.existence_status = False
+
+    # notExists, existence_status = True -> blocks child
+    not_exist_node = attack_graph.add_node(not_exist_attack_step_type)
+    not_exist_node.existence_status = True
+
+    # Defense -> blocks child when enabled
+    defense_step_node = attack_graph.add_node(defense_step_type)
+
+    and_node_blocked_by_defense = attack_graph.add_node(and_attack_step_type)
+    and_node_blocked_by_defense.parents.add(defense_step_node)
+
+    and_node_blocked_by_exist = attack_graph.add_node(and_attack_step_type)
+    and_node_blocked_by_exist.parents.add(exist_node)
+
+    and_node_blocked_by_not_exist = attack_graph.add_node(and_attack_step_type)
+    and_node_blocked_by_not_exist.parents.add(not_exist_node)
+
+    or_node_blocked_by_defense = attack_graph.add_node(or_attack_step_type)
+    or_node_blocked_by_defense.parents.add(defense_step_node)
+
+    or_node_blocked_by_exist = attack_graph.add_node(or_attack_step_type)
+    or_node_blocked_by_exist.parents.add(exist_node)
+
+    or_node_blocked_by_not_exist = attack_graph.add_node(or_attack_step_type)
+    or_node_blocked_by_not_exist.parents.add(not_exist_node)
+
+    # Or node with any parent that is not blocking will not be blocked
+    or_node_not_blocked = attack_graph.add_node(or_attack_step_type)
+    or_node_not_blocked.parents.add(and_node_blocked_by_defense) # the and node is blocked but not the or node
+
+    impossible_and_node = attack_graph.add_node(and_attack_step_type)
+    impossible_attack_steps.add(impossible_and_node)
+    impossible_attack_steps.add(impossible_and_node)
+
+    # Make sure unviable
+    enabled_defenses = {defense_step_node}
+
+    sim_state = MalSimulatorState(
+        attack_graph=attack_graph,
+        settings=MalSimulatorSettings(),
+        graph_state=GraphState({}, enabled_defenses, impossible_attack_steps, {}),
+        enabled_defenses=enabled_defenses
+    )
+
+    assert node_is_blocked(sim_state, and_node_blocked_by_defense)
+    assert node_is_blocked(sim_state, and_node_blocked_by_exist)
+    assert node_is_blocked(sim_state, and_node_blocked_by_not_exist)
+    assert node_is_blocked(sim_state, or_node_blocked_by_defense)
+    assert node_is_blocked(sim_state, or_node_blocked_by_exist)
+    assert node_is_blocked(sim_state, or_node_blocked_by_not_exist)
+    assert not node_is_blocked(sim_state, or_node_not_blocked)
+    assert node_is_blocked(sim_state, impossible_and_node)

--- a/tests/test_graph_processing.py
+++ b/tests/test_graph_processing.py
@@ -404,7 +404,9 @@ def test_node_is_blocked(dummy_lang_graph: LanguageGraph) -> None:
 
     # Or node with any parent that is not blocking will not be blocked
     or_node_not_blocked = attack_graph.add_node(or_attack_step_type)
-    or_node_not_blocked.parents.add(and_node_blocked_by_defense) # the and node is blocked but not the or node
+    or_node_not_blocked.parents.add(
+        and_node_blocked_by_defense
+    )  # the and node is blocked but not the or node
 
     impossible_and_node = attack_graph.add_node(and_attack_step_type)
     impossible_attack_steps.add(impossible_and_node)
@@ -417,7 +419,7 @@ def test_node_is_blocked(dummy_lang_graph: LanguageGraph) -> None:
         attack_graph=attack_graph,
         settings=MalSimulatorSettings(),
         graph_state=GraphState({}, enabled_defenses, impossible_attack_steps, {}),
-        enabled_defenses=enabled_defenses
+        enabled_defenses=enabled_defenses,
     )
 
     assert node_is_blocked(sim_state, and_node_blocked_by_defense)

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -86,7 +86,8 @@ def test_reset(corelang_lang_graph: LanguageGraph, model: Model) -> None:
     )
 
     blocked_before = {
-        n.full_name: node_is_blocked(sim.sim_state, n) for n in sim.sim_state.attack_graph.nodes.values()
+        n.full_name: node_is_blocked(sim.sim_state, n)
+        for n in sim.sim_state.attack_graph.nodes.values()
     }
     necessity_before = {
         n.full_name: v for n, v in sim.sim_state.graph_state.necessity_per_node.items()
@@ -280,7 +281,6 @@ def test_defender_step(corelang_lang_graph: LanguageGraph, model: Model) -> None
         [attack_step],
     )
     assert enabled == []
-
 
 
 def test_node_full_names_to_simulator(

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -32,6 +32,7 @@ from dataclasses import asdict
 import numpy as np
 import pytest
 
+from malsim.mal_simulator.graph_utils import node_is_blocked
 from malsim.policies.random_agent import RandomAgent
 from .conftest import get_node
 
@@ -462,11 +463,11 @@ def test_is_traversable(corelang_lang_graph: LanguageGraph, model: Model) -> Non
                     p in attacker_state.performed_nodes
                     for p in node.parents
                     if p.type in ('or', 'and')
-                ) or not sim.node_is_viable(node)
+                ) or sim.node_is_blocked(node)
             if node.type == 'or' and not sim.node_is_traversable(
                 attacker_state.performed_nodes, node
             ):
-                assert not sim.node_is_viable(node)
+                assert sim.node_is_blocked(node)
         else:
             assert not sim.node_is_traversable(attacker_state.performed_nodes, node)
 
@@ -523,6 +524,13 @@ def test_not_initial_compromise_entrypoints_unviable_step(
     attacker_state = sim.step(
         {attacker_name: ['OS App:fullAccess'], defender_name: ['OS App:notPresent']}
     )[attacker_name]
+
+    node = attack_graph.get_node_by_full_name('OS App:fullAccess')
+    assert (
+        node_is_blocked(sim.sim_state, node)
+        or node not in attacker_state.action_surface
+    )
+
     assert attacker_state.performed_nodes == set()
     assert attacker_state.action_surface == set()
 

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -85,8 +85,8 @@ def test_reset(corelang_lang_graph: LanguageGraph, model: Model) -> None:
         ),
     )
 
-    viability_before = {
-        n.full_name: v for n, v in sim.sim_state.graph_state.viability_per_node.items()
+    blocked_before = {
+        n.full_name: node_is_blocked(sim.sim_state, n) for n in sim.sim_state.attack_graph.nodes.values()
     }
     necessity_before = {
         n.full_name: v for n, v in sim.sim_state.graph_state.necessity_per_node.items()
@@ -124,9 +124,9 @@ def test_reset(corelang_lang_graph: LanguageGraph, model: Model) -> None:
     sim = MalSimulator(
         attack_graph, sim_settings=MalSimulatorSettings(seed=10), agents=()
     )
-    for node, viable in sim.sim_state.graph_state.viability_per_node.items():
-        # viability is the same after reset
-        assert viability_before[node.full_name] == viable
+    for node in sim.sim_state.attack_graph.nodes.values():
+        # blocked is the same after reset
+        assert blocked_before[node.full_name] == node_is_blocked(sim.sim_state, node)
 
     for node, necessary in sim.sim_state.graph_state.necessity_per_node.items():
         # necessity is the same after reset
@@ -264,24 +264,23 @@ def test_defender_step(corelang_lang_graph: LanguageGraph, model: Model) -> None
     assert isinstance(defender_agent, DefenderState)
 
     defense_step = get_node(attack_graph, 'OS App:notPresent')
-    enabled, made_unviable = defender_step(
+    enabled = defender_step(
         sim.sim_state,
         defender_agent,
         [defense_step],
     )
     assert enabled == [defense_step]
-    assert made_unviable
 
     # Can not defend attack_step
     attack_step = get_node(attack_graph, 'OS App:attemptUseVulnerability')
     assert attack_step
-    enabled, made_unviable = defender_step(
+    enabled = defender_step(
         sim.sim_state,
         defender_agent,
         [attack_step],
     )
     assert enabled == []
-    assert not made_unviable
+
 
 
 def test_node_full_names_to_simulator(
@@ -936,7 +935,6 @@ def test_agent_state_views_simple(
     assert os_app_attempt_deny not in asv.action_surface
     assert dsv.step_action_surface_removals == {program2_not_present}
     assert dsv.step_compromised_nodes == {os_app_attempt_deny}
-    assert len(dsv.step_unviable_nodes) == 48
 
     # Go through an attack step that already has some children in the attack
     # surface(OS App:accessNetworkAndConnections in this case)
@@ -956,7 +954,6 @@ def test_agent_state_views_simple(
     assert os_app_spec_access not in asv.action_surface
     assert dsv.step_action_surface_removals == set()
     assert dsv.step_compromised_nodes == {os_app_spec_access}
-    assert len(dsv.step_unviable_nodes) == 0
 
     # Evaluate the agent state views after stepping through an attack step and
     # a defense that would prevent it from occurring
@@ -973,23 +970,10 @@ def test_agent_state_views_simple(
     assert asv.step_action_surface_additions == set()
     assert dsv.step_action_surface_additions == set()
     assert {a.full_name for a in asv.step_action_surface_removals} == {
-        'OS App:accessNetworkAndConnections',
-        'OS App:attemptApplicationRespondConnectThroughData',
-        'OS App:attemptAuthorizedApplicationRespondConnectThroughData',
-        'OS App:attemptModify',
-        'OS App:attemptRead',
-        'OS App:specificAccessDelete',
-        'OS App:specificAccessModify',
-        # 'OS App:bypassContainerization',
-        'OS App:specificAccessRead',
         'OS App:successfulDeny',
-        'Program 1:localConnect',
-        'Program 2:localConnect',
-        # 'IDPS 1:localConnect',
     }
     assert dsv.step_action_surface_removals == {os_app_not_present}
     assert dsv.step_compromised_nodes == set()
-    assert len(dsv.step_unviable_nodes) == 53
 
     # Recording of the simulation
     assert sim.recording == {
@@ -1474,7 +1458,6 @@ def test_simulator_seed_setting() -> None:
             seed=100,
             attack_surface=AttackSurfaceSettings(
                 skip_compromised=True,
-                skip_unviable=True,
                 skip_unnecessary=False,
             ),
             run_defense_step_bernoullis=False,

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -498,7 +498,7 @@ def test_not_initial_compromise_entrypoints(
     assert attacker_state.action_surface == set(entry_point.children)
 
 
-def test_not_initial_compromise_entrypoints_unviable_step(
+def test_not_initial_compromise_entrypoints_can_not_be_blocked(
     corelang_lang_graph: LanguageGraph, model: Model
 ) -> None:
     attack_graph = AttackGraph(corelang_lang_graph, model)
@@ -520,7 +520,8 @@ def test_not_initial_compromise_entrypoints_unviable_step(
 
     attacker_state = sim.reset()[attacker_name]
 
-    # Step should not succeed if defender defended the entrypoint
+    # Step will succeed even if defender defended the entrypoint.
+    # Entry points can always be compromised.
     attacker_state = sim.step(
         {attacker_name: ['OS App:fullAccess'], defender_name: ['OS App:notPresent']}
     )[attacker_name]
@@ -531,8 +532,8 @@ def test_not_initial_compromise_entrypoints_unviable_step(
         or node not in attacker_state.action_surface
     )
 
-    assert attacker_state.performed_nodes == set()
-    assert attacker_state.action_surface == set()
+    assert attacker_state.performed_nodes == {node}
+    assert attacker_state.action_surface == set(node.children)
 
 
 def test_is_compromised(corelang_lang_graph: LanguageGraph, model: Model) -> None:


### PR DESCRIPTION
- Store enabled defenses in sim_state instead of calculating viability each step
- Find out if a node is blocked before adding it to action surface or compromising it
- Defense surface only contains non-enabled defenses (same as before but more explicit now)
- Persistence on attack steps
- Persistence on entry points even if they are not performed at start
- Keep old viability calculation functions (this explains the lack of deleted lines)

Note:
- A lot of the test_example_scenario tests changed and they are hard to understand. I have decided to trust that their change was just due to the added persistence, after writing some more attack surface tests to make sure it is calculated correctly.
