### PR TITLE
Multiple potential entrypoint sets

### DIFF
--- a/malsim/config/agent_settings.py
+++ b/malsim/config/agent_settings.py
@@ -52,7 +52,7 @@ class AttackerSettings(AgentRuntimeMixin, Generic[T]):
     """Settings for an attacker in a scenario."""
 
     name: str
-    entry_points: Set[T]
+    entry_points: tuple[Set[T], ...] | Set[T]
     policy: type | None = None
     actionable_steps: NodePropertyRule[bool] | None = None
     rewards: NodePropertyRule[float] | None = None
@@ -67,9 +67,17 @@ class AttackerSettings(AgentRuntimeMixin, Generic[T]):
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {
             'type': AgentType.ATTACKER.value,
-            'entry_points': {
+            'entry_points': [
+                {
+                    n.full_name if isinstance(n, AttackGraphNode) else n
+                    for n in self.entry_points
+                }
+            ]
+            if isinstance(self.entry_points, Set)
+            else {
                 n.full_name if isinstance(n, AttackGraphNode) else n
-                for n in self.entry_points
+                for entry_points in self.entry_points
+                for n in entry_points
             },
         }
         if self.goals:
@@ -90,6 +98,23 @@ class AttackerSettings(AgentRuntimeMixin, Generic[T]):
         if isinstance(self.reward_mode, str):
             self.reward_mode = RewardMode[self.reward_mode]
 
+    def _convert_entry_points_to_nodes(
+        self, attack_graph: AttackGraph, entry_points: tuple[Set[T], ...] | Set[T]
+    ) -> tuple[Set[AttackGraphNode], ...] | Set[AttackGraphNode]:
+        """
+        Convert entry points from full names to nodes,
+        handling both single and multiple entry point sets
+        """
+        if isinstance(entry_points, Set):
+            return frozenset(
+                full_name_or_node_to_node(attack_graph, ep) for ep in entry_points
+            )
+        else:
+            return tuple(
+                frozenset(full_name_or_node_to_node(attack_graph, ep) for ep in eps)
+                for eps in entry_points
+            )
+
     def convert_to_attack_graph_nodes(
         self, attack_graph: AttackGraph
     ) -> AttackerSettings[AttackGraphNode]:
@@ -98,8 +123,8 @@ class AttackerSettings(AgentRuntimeMixin, Generic[T]):
             goals=frozenset(
                 full_name_or_node_to_node(attack_graph, g) for g in self.goals
             ),
-            entry_points=frozenset(
-                full_name_or_node_to_node(attack_graph, ep) for ep in self.entry_points
+            entry_points=self._convert_entry_points_to_nodes(
+                attack_graph, self.entry_points
             ),
             name=self.name,
             policy=self.policy,

--- a/malsim/config/agent_settings.py
+++ b/malsim/config/agent_settings.py
@@ -47,6 +47,21 @@ class AgentRuntimeMixin:
 T = TypeVar('T', bound=AttackGraphNode | str, covariant=True)
 
 
+def _entry_points_to_dict(
+    entry_points: tuple[Set[T], ...] | Set[T],
+) -> list[Set[str]] | set[str]:
+    if isinstance(entry_points, Set):
+        return {
+            ep.full_name if isinstance(ep, AttackGraphNode) else ep
+            for ep in entry_points
+        }
+    else:
+        return [
+            {ep.full_name if isinstance(ep, AttackGraphNode) else ep for ep in eps}
+            for eps in entry_points
+        ]
+
+
 @dataclass
 class AttackerSettings(AgentRuntimeMixin, Generic[T]):
     """Settings for an attacker in a scenario."""
@@ -67,18 +82,7 @@ class AttackerSettings(AgentRuntimeMixin, Generic[T]):
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {
             'type': AgentType.ATTACKER.value,
-            'entry_points': [
-                {
-                    n.full_name if isinstance(n, AttackGraphNode) else n
-                    for n in self.entry_points
-                }
-            ]
-            if isinstance(self.entry_points, Set)
-            else {
-                n.full_name if isinstance(n, AttackGraphNode) else n
-                for entry_points in self.entry_points
-                for n in entry_points
-            },
+            'entry_points': _entry_points_to_dict(self.entry_points),
         }
         if self.goals:
             d['goals'] = {

--- a/malsim/config/agent_settings_factories.py
+++ b/malsim/config/agent_settings_factories.py
@@ -1,3 +1,4 @@
+from collections.abc import Set
 from typing import Any
 
 
@@ -59,6 +60,28 @@ def _validate_agent_dict(d: dict[str, Any]) -> dict[str, Any]:
     return d
 
 
+def _load_entry_points(d: Any) -> tuple[Set[str], ...] | Set[str]:
+    if d is None:
+        return frozenset()
+    elif isinstance(d, set):
+        return frozenset(d)
+    elif isinstance(d, (list, tuple)):
+        # Can be a list of strings or a list of sets/lists with strings
+        if all(isinstance(ep, str) for ep in d):
+            return frozenset(d)
+        elif all(isinstance(ep, (set, list)) for ep in d):
+            return tuple(frozenset(ep) for ep in d)
+        else:
+            raise ValueError(
+                'entry_points list must contain either '
+                'all strings or all sets/lists of strings'
+            )
+    else:
+        raise ValueError(
+            f'entry_points must be a set or list of strings, got {type(d)}'
+        )
+
+
 def agent_settings_from_dict(
     name: str,
     d: dict[str, Any],
@@ -84,7 +107,7 @@ def agent_settings_from_dict(
     if agent_type == AgentType.ATTACKER:
         return AttackerSettings(
             name=name,
-            entry_points=frozenset(d['entry_points']),
+            entry_points=_load_entry_points(d.get('entry_points')),
             goals=frozenset(d.get('goals', [])),
             ttc_dists=NodePropertyRule.from_optional_dict(d.get('ttc_overrides')),
             policy=policy,

--- a/malsim/mal_simulator/attacker_state.py
+++ b/malsim/mal_simulator/attacker_state.py
@@ -12,6 +12,7 @@ class AttackerState(AgentState):
     """Stores the state of an attacker in the simulator"""
 
     settings: AttackerSettings[AttackGraphNode]
+    entry_points: Set[AttackGraphNode]
     # Number of attempts to compromise a step (used for ttc caculations)
     num_attempts: Mapping[AttackGraphNode, int]
     # Steps attempted but not succeeded (because of TTC value)

--- a/malsim/mal_simulator/attacker_state_factories.py
+++ b/malsim/mal_simulator/attacker_state_factories.py
@@ -127,7 +127,7 @@ def get_entry_points(
     If multiple sets of entry points are given, sample one set from the options.
     """
 
-    if isinstance(attacker_settings.entry_points, set):
+    if isinstance(attacker_settings.entry_points, Set):
         return frozenset(
             full_names_or_nodes_to_nodes(
                 sim_state.attack_graph, attacker_settings.entry_points
@@ -136,7 +136,6 @@ def get_entry_points(
     else:
         # Multiple potential entry point sets given
         # - sample one set of entry points from the options
-        assert isinstance(attacker_settings.entry_points, tuple)
         chosen_entry_points = rng.choice(attacker_settings.entry_points)
         return set(
             full_names_or_nodes_to_nodes(sim_state.attack_graph, chosen_entry_points)

--- a/malsim/mal_simulator/attacker_state_factories.py
+++ b/malsim/mal_simulator/attacker_state_factories.py
@@ -136,7 +136,7 @@ def get_entry_points(
     else:
         # Multiple potential entry point sets given
         # - sample one set of entry points from the options
-        chosen_entry_points = rng.choice(attacker_settings.entry_points)
+        chosen_entry_points = rng.choice(list(attacker_settings.entry_points)) # type: ignore
         return set(
             full_names_or_nodes_to_nodes(sim_state.attack_graph, chosen_entry_points)
         )

--- a/malsim/mal_simulator/attacker_state_factories.py
+++ b/malsim/mal_simulator/attacker_state_factories.py
@@ -38,6 +38,7 @@ def create_attacker_state(
     attack_surface_settings: AttackSurfaceSettings,
     attacker_settings: AttackerSettings[AttackGraphNode],
     name: str,
+    entry_points: Set[AttackGraphNode],
     new_performed_nodes: Set[AttackGraphNode],
     ttc_values: Mapping[AttackGraphNode, float],
     impossible_steps: Set[AttackGraphNode],
@@ -78,7 +79,7 @@ def create_attacker_state(
     )
 
     if not previous_state and not sim_state.settings.compromise_entrypoints_at_start:
-        action_surface |= attacker_settings.entry_points
+        action_surface |= entry_points
 
     iteration = previous_state.iteration if previous_state else 0
     if new_performed_nodes:
@@ -86,6 +87,7 @@ def create_attacker_state(
 
     return AttackerState(
         name,
+        entry_points=entry_points,
         sim_state=sim_state,
         iteration=iteration + 1,
         performed_nodes_order=performed_nodes_order,
@@ -115,6 +117,32 @@ def get_entrypoint_compromises(
     return step_compromised_nodes
 
 
+def get_entry_points(
+    sim_state: MalSimulatorState,
+    attacker_settings: AttackerSettings[AttackGraphNode],
+    rng: np.random.Generator,
+) -> Set[AttackGraphNode]:
+    """
+    Get entry points as set of AttackGraphNodes from attacker settings.
+    If multiple sets of entry points are given, sample one set from the options.
+    """
+
+    if isinstance(attacker_settings.entry_points, set):
+        return frozenset(
+            full_names_or_nodes_to_nodes(
+                sim_state.attack_graph, attacker_settings.entry_points
+            )
+        )
+    else:
+        # Multiple potential entry point sets given
+        # - sample one set of entry points from the options
+        assert isinstance(attacker_settings.entry_points, tuple)
+        chosen_entry_points = rng.choice(attacker_settings.entry_points)
+        return set(
+            full_names_or_nodes_to_nodes(sim_state.attack_graph, chosen_entry_points)
+        )
+
+
 def initial_attacker_state(
     sim_state: MalSimulatorState,
     sim_settings: MalSimulatorSettings,
@@ -136,11 +164,7 @@ def initial_attacker_state(
             sim_state.graph_state.impossible_attack_steps,
         )
     )
-    entry_points = set(
-        full_names_or_nodes_to_nodes(
-            sim_state.attack_graph, attacker_settings.entry_points
-        )
-    )
+    entry_points = get_entry_points(sim_state, attacker_settings, rng)
     new_compromised_nodes: Set[AttackGraphNode] = set()
 
     if sim_state.settings.compromise_entrypoints_at_start:
@@ -154,6 +178,7 @@ def initial_attacker_state(
         ttc_values=ttc_values,
         impossible_steps=impossible_steps,
         new_performed_nodes=new_compromised_nodes,
+        entry_points=entry_points,
     )
 
 

--- a/malsim/mal_simulator/attacker_state_factories.py
+++ b/malsim/mal_simulator/attacker_state_factories.py
@@ -136,7 +136,7 @@ def get_entry_points(
     else:
         # Multiple potential entry point sets given
         # - sample one set of entry points from the options
-        chosen_entry_points = rng.choice(list(attacker_settings.entry_points)) # type: ignore
+        chosen_entry_points = rng.choice(list(attacker_settings.entry_points))  # type: ignore
         return set(
             full_names_or_nodes_to_nodes(sim_state.attack_graph, chosen_entry_points)
         )

--- a/malsim/mal_simulator/simulator.py
+++ b/malsim/mal_simulator/simulator.py
@@ -529,6 +529,7 @@ def step(
             attack_surface_settings=sim_state.settings.attack_surface,
             attacker_settings=attacker_state.settings,
             name=attacker_state.name,
+            entry_points=attacker_state.entry_points,
             new_performed_nodes=frozenset(agent_compromised),
             new_attempted_nodes=frozenset(agent_attempted),
             previous_state=attacker_state,

--- a/tests/test_attacker_settings.py
+++ b/tests/test_attacker_settings.py
@@ -13,10 +13,12 @@ def test_attacker_settings_single_entry_points_set() -> None:
 def test_attacker_settings_single_entry_points_set_in_list() -> None:
     settings = AttackerSettings(
         name='Attacker1',
-        entry_points=frozenset(({'User:3:phishing', 'Host:0:connect'})),
+        entry_points=frozenset({'User:3:phishing', 'Host:0:connect'}),
         goals=frozenset({'Data:2:read'}),
     )
-    assert settings.entry_points == frozenset({'User:3:phishing', 'Host:0:connect'})
+    assert settings.entry_points == frozenset(
+        ({'User:3:phishing', 'Host:0:connect'}),
+    )
 
 
 def test_attacker_settings_multiple_entry_points_sets_in_list() -> None:

--- a/tests/test_attacker_settings.py
+++ b/tests/test_attacker_settings.py
@@ -1,0 +1,31 @@
+from malsim.config.agent_settings import AttackerSettings
+
+
+def test_attacker_settings_single_entry_points_set() -> None:
+    settings = AttackerSettings(
+        name='Attacker1',
+        entry_points=frozenset({'User:3:phishing', 'Host:0:connect'}),
+        goals=frozenset({'Data:2:read'}),
+    )
+    assert settings.entry_points == frozenset({'User:3:phishing', 'Host:0:connect'})
+
+
+def test_attacker_settings_single_entry_points_set_in_list() -> None:
+    settings = AttackerSettings(
+        name='Attacker1',
+        entry_points=frozenset(({'User:3:phishing', 'Host:0:connect'})),
+        goals=frozenset({'Data:2:read'}),
+    )
+    assert settings.entry_points == frozenset({'User:3:phishing', 'Host:0:connect'})
+
+
+def test_attacker_settings_multiple_entry_points_sets_in_list() -> None:
+    settings = AttackerSettings(
+        name='Attacker1',
+        entry_points=({'User:3:phishing', 'Host:0:connect'}, {'User:4:phishing'}),
+        goals=frozenset({'Data:2:read'}),
+    )
+    assert settings.entry_points == (
+        {'User:3:phishing', 'Host:0:connect'},
+        {'User:4:phishing'},
+    )

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -1771,3 +1771,25 @@ def test_simulator_multiple_entry_point_sets_in_attacker_settings(model: Model) 
         sim.get_node('OS App:fullAccess'),
         sim.get_node('Program 2:fullAccess'),
     }
+
+
+def test_simulator_multiple_entry_point_sets_scenario():
+    """
+    Test that if a scenario has an attacker with multiple entry point sets,
+    one set is picked when initializing the simulator
+    """
+    scenario = Scenario.load_from_file(
+        'tests/testdata/scenarios/bfs_vs_bfs_scenario_multiple_entrypoint_sets.yml'
+    )
+
+    chosen_entry_points = list()
+    for i in range(10):
+        sim = MalSimulator.from_scenario(scenario, sim_settings=MalSimulatorSettings(seed=i))
+        attacker_state = sim.agent_states['attacker1']
+        assert isinstance(attacker_state, AttackerState)
+        chosen_entry_points.append(attacker_state.entry_points)
+
+    # Make sure not all entrypoints are the same across all runs
+    assert len(set(frozenset(e) for e in chosen_entry_points)) == 2, (
+        'Entry points are the same across all runs, expected some variability'
+    )

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -1732,3 +1732,28 @@ def test_simulator_sim_settings_from_scenario(
 
     sim = MalSimulator.from_scenario(scenario)
     assert sim.sim_settings.seed is None
+
+
+def test_simulator_multiple_entry_point_sets_in_attacker_settings(model: Model) -> None:
+    """
+    Test that if an attacker has multiple entry point sets,
+    one set is picked when initializing the simulator
+    """
+    attacker_settings = AttackerSettings(
+        name='Attacker1',
+        entry_points=({'OS App:fullAccess', 'Program 2:fullAccess'}, {'Data:5:read'}),
+    )
+
+    corelang_file_name = 'tests/testdata/langs/org.mal-lang.coreLang-1.0.0.mar'
+    scenario = Scenario(
+        corelang_file_name,
+        model,
+        agents=(attacker_settings,),
+        sim_settings=MalSimulatorSettings(seed=100),
+    )
+    sim = MalSimulator.from_scenario(scenario)
+    assert (
+        sim.agent_states['Attacker1'].entry_points
+        in sim.agent_settings['Attacker1'].entry_points
+    )
+    assert sim.agent_states['Attacker1'].entry_points == {sim.get_node('Data:5:read')}

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -1752,8 +1752,22 @@ def test_simulator_multiple_entry_point_sets_in_attacker_settings(model: Model) 
         sim_settings=MalSimulatorSettings(seed=100),
     )
     sim = MalSimulator.from_scenario(scenario)
-    assert (
-        sim.agent_states['Attacker1'].entry_points
-        in sim.agent_settings['Attacker1'].entry_points
+    attacker_state = sim.agent_states['Attacker1']
+    assert isinstance(attacker_state, AttackerState)
+    assert isinstance(attacker_settings.entry_points, tuple)
+    assert attacker_state.entry_points == {sim.get_node('Data:5:read')}
+
+    scenario = Scenario(
+        corelang_file_name,
+        model,
+        agents=(attacker_settings,),
+        sim_settings=MalSimulatorSettings(seed=7),
     )
-    assert sim.agent_states['Attacker1'].entry_points == {sim.get_node('Data:5:read')}
+    sim = MalSimulator.from_scenario(scenario)
+    attacker_state = sim.agent_states['Attacker1']
+    assert isinstance(attacker_state, AttackerState)
+    assert isinstance(attacker_settings.entry_points, tuple)
+    assert attacker_state.entry_points == {
+        sim.get_node('OS App:fullAccess'),
+        sim.get_node('Program 2:fullAccess'),
+    }

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -1773,7 +1773,7 @@ def test_simulator_multiple_entry_point_sets_in_attacker_settings(model: Model) 
     }
 
 
-def test_simulator_multiple_entry_point_sets_scenario():
+def test_simulator_multiple_entry_point_sets_scenario() -> None:
     """
     Test that if a scenario has an attacker with multiple entry point sets,
     one set is picked when initializing the simulator
@@ -1782,14 +1782,16 @@ def test_simulator_multiple_entry_point_sets_scenario():
         'tests/testdata/scenarios/bfs_vs_bfs_scenario_multiple_entrypoint_sets.yml'
     )
 
-    chosen_entry_points = list()
+    chosen_entry_points = set()
     for i in range(10):
-        sim = MalSimulator.from_scenario(scenario, sim_settings=MalSimulatorSettings(seed=i))
+        sim = MalSimulator.from_scenario(
+            scenario, sim_settings=MalSimulatorSettings(seed=i)
+        )
         attacker_state = sim.agent_states['attacker1']
         assert isinstance(attacker_state, AttackerState)
-        chosen_entry_points.append(attacker_state.entry_points)
+        chosen_entry_points.add(frozenset(attacker_state.entry_points))
 
     # Make sure not all entrypoints are the same across all runs
-    assert len(set(frozenset(e) for e in chosen_entry_points)) == 2, (
+    assert len(chosen_entry_points) == 2, (
         'Entry points are the same across all runs, expected some variability'
     )

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -560,6 +560,7 @@ def test_scenario_advanced_agent_settings() -> None:
     assert attacker.type == AgentType.ATTACKER
 
     # entry points
+    assert isinstance(attacker.entry_points, frozenset)
     assert {n.full_name for n in attacker.entry_points} == {
         'User:3:phishing',
         'Host:0:connect',

--- a/tests/testdata/scenarios/bfs_vs_bfs_scenario_multiple_entrypoint_sets.yml
+++ b/tests/testdata/scenarios/bfs_vs_bfs_scenario_multiple_entrypoint_sets.yml
@@ -1,0 +1,29 @@
+lang_file: ../langs/org.mal-lang.coreLang-1.0.0.mar
+model_file: ../models/basic_model.yml
+
+agents:
+  'attacker1':
+    agent_class: BreadthFirstAttacker
+    type: attacker
+    reward_mode: ONE_OFF
+    config:
+      seed: 1
+      action_ordering: random
+    entry_points:
+      - ['Program 1:fullAccess']
+      - ['Program 2:fullAccess']
+
+  'defender1':
+    agent_class: BreadthFirstAttacker
+    type: defender
+    config:
+      seed: 1
+      action_ordering: random
+    rewards:
+      by_asset_name:
+        Program 1:
+          notPresent: 2
+          supplyChainAuditing: 7
+        Program 2:
+          notPresent: 3
+          supplyChainAuditing: 7


### PR DESCRIPTION
Add the option to give more than one set of entry points in the scenario and the scenario file.

In scenario file previously:
```
  'Attacker1':
    type: attacker
    entry_points:
      - 'entrypoint1'
      - 'entrypoint2'
```

This is still supported, but additionally you can give multiple sets/lists:

```
  'Attacker1':
    type: attacker
    entry_points:
      - ['entrypoint1', 'entrypoint2']
      - ['entrypoint3', 'entrypoint4']
```

When running a simulation with this scenario, the attacker agent will be given one of the specified entry point lists, so either ['entrypoint1', 'entrypoint2'] or ['entrypoint3', 'entrypoint4'].
The rng is the same one seeded by mal sim settings so determinism can be fulfilled.

This also works in the AttackerSettings where you can now either give a set of entry point nodes or a tuple containing multiple sets of entry point nodes.
